### PR TITLE
refactor: move circuits, tenancy, bgp types into 'types' pkg

### DIFF
--- a/circuits/circuit.go
+++ b/circuits/circuit.go
@@ -4,83 +4,38 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
-	"github.com/neverbeencloser/gonautobot/types/nested"
-)
-
-type (
-	// Circuit : defines a circuit entry in Nautobot
-	Circuit struct {
-		ID           string             `json:"id"`
-		Display      string             `json:"display"`
-		URL          string             `json:"url"`
-		CircuitID    string             `json:"cid"`
-		Provider     nested.Provider    `json:"provider"`
-		Type         nested.CircuitType `json:"type"`
-		Status       types.LabelValue   `json:"status"`
-		Tenant       nested.Tenant      `json:"tenant"`
-		InstallDate  string             `json:"install_date"`
-		CommitRate   int                `json:"commit_rate"`
-		Description  string             `json:"description"`
-		TerminationA Termination        `json:"termination_a"`
-		TerminationZ Termination        `json:"termination_z"`
-		Comments     string             `json:"comments"`
-		Created      string             `json:"created"`
-		LastUpdated  time.Time          `json:"last_updated"`
-		Tags         []types.Tag        `json:"tags"`
-		NotesURL     string             `json:"notes_url"`
-		CustomFields map[string]any     `json:"custom_fields"`
-	}
-
-	// CircuitRequest : Models a new circuit entry in Nautobot.
-	CircuitRequest struct {
-		CircuitID    string         `json:"cid"`
-		Provider     string         `json:"provider"`
-		Type         string         `json:"circuit_type"`
-		Status       string         `json:"status"`
-		Tenant       string         `json:"tenant,omitempty"`
-		InstallDate  string         `json:"install_date,omitempty"`
-		CommitRate   int            `json:"commit_rate,omitempty"`
-		Description  string         `json:"description,omitempty"`
-		TerminationA Termination    `json:"termination_a,omitempty"`
-		TerminationZ Termination    `json:"termination_z,omitempty"`
-		Comments     string         `json:"comments,omitempty"`
-		Created      string         `json:"created,omitempty"`
-		Tags         []types.Tag    `json:"tags,omitempty"`
-		CustomFields map[string]any `json:"custom_fields,omitempty"`
-	}
 )
 
 // CircuitGet : Go function to process requests for the endpoint: /api/circuits/circuits/
 //
 // https://demo.nautobot.com/api/docs/#/circuits/circuits_circuits_list
-func (c *Client) CircuitGet(uuid string) (Circuit, error) {
+func (c *Client) CircuitGet(uuid string) (types.Circuit, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("circuits/circuits/%s/", uuid), nil, nil)
 	if err != nil {
-		return Circuit{}, err
+		return types.Circuit{}, err
 	}
 
-	ret := new(Circuit)
+	ret := new(types.Circuit)
 	return *ret, c.UnmarshalDo(req, ret)
 }
 
 // CircuitFilter : Go function to process requests for the endpoint: /api/circuits/circuits/
 //
 // https://demo.nautobot.com/api/docs/#/circuits/circuits_circuits_list
-func (c *Client) CircuitFilter(q *url.Values) ([]Circuit, error) {
-	resp := make([]Circuit, 0)
-	return resp, core.Paginate[Circuit](c.Client, "circuits/circuits/", q, &resp)
+func (c *Client) CircuitFilter(q *url.Values) ([]types.Circuit, error) {
+	resp := make([]types.Circuit, 0)
+	return resp, core.Paginate[types.Circuit](c.Client, "circuits/circuits/", q, &resp)
 }
 
 // CircuitAll : Go function to process requests for the endpoint: /api/circuits/circuits/
 //
 // https://demo.nautobot.com/api/docs/#/circuits/circuits_circuits_list
-func (c *Client) CircuitAll() ([]Circuit, error) {
-	resp := make([]Circuit, 0)
-	return resp, core.Paginate[Circuit](c.Client, "circuits/circuits/", nil, &resp)
+func (c *Client) CircuitAll() ([]types.Circuit, error) {
+	resp := make([]types.Circuit, 0)
+	return resp, core.Paginate[types.Circuit](c.Client, "circuits/circuits/", nil, &resp)
 }
 
 // CircuitDelete : Go function to process requests for the endpoint: /api/circuits/circuits/
@@ -97,11 +52,11 @@ func (c *Client) CircuitDelete(uuid string) error {
 // CircuitCreate : Go function to process requests for the endpoint: /api/circuits/circuits/
 //
 // https://demo.nautobot.com/api/docs/#/circuits/circuits_circuits_create
-func (c *Client) CircuitCreate(r CircuitRequest) (Circuit, error) {
+func (c *Client) CircuitCreate(r types.CircuitRequest) (types.Circuit, error) {
 	req, err := c.Request(http.MethodPost, "circuits/circuits/", r, nil)
 	if err != nil {
-		return Circuit{}, err
+		return types.Circuit{}, err
 	}
-	var ret Circuit
+	var ret types.Circuit
 	return ret, c.UnmarshalDo(req, &ret)
 }

--- a/dcim/location.go
+++ b/dcim/location.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
-	"github.com/neverbeencloser/gonautobot/tenancy"
 	"github.com/neverbeencloser/gonautobot/types"
 )
 
@@ -17,40 +16,40 @@ const (
 type (
 	// Location : Represents a location in Nautobot.
 	Location struct {
-		ID              uuid.UUID       `json:"id"`
-		ASN             *int            `json:"asn"`
-		CircuitCount    int             `json:"circuit_count"`
-		Comments        string          `json:"comments"`
-		ContactEmail    string          `json:"contact_email"`
-		ContactName     string          `json:"contact_name"`
-		ContactPhone    string          `json:"contact_phone"`
-		Created         time.Time       `json:"created"`
-		CustomFields    map[string]any  `json:"custom_fields"`
-		Description     string          `json:"description"`
-		DeviceCount     int             `json:"device_count"`
-		Display         string          `json:"display"`
-		Facility        string          `json:"facility"`
-		LastUpdated     time.Time       `json:"last_updated"`
-		Latitude        *float64        `json:"latitude,string"`
-		LocationType    LocationType    `json:"location_type"`
-		Longitude       *float64        `json:"longitude,string"`
-		Name            string          `json:"name"`
-		NaturalSlug     string          `json:"natural_slug"`
-		NotesURL        string          `json:"notes_url"`
-		ObjectType      string          `json:"object_type"`
-		Parent          *Location       `json:"parent"`
-		PhysicalAddress string          `json:"physical_address"`
-		PrefixCount     int             `json:"prefix_count"`
-		RackCount       int             `json:"rack_count"`
-		ShippingAddress string          `json:"shipping_address"`
-		Status          types.Status    `json:"status"`
-		Tags            []types.Tag     `json:"tags"`
-		Tenant          *tenancy.Tenant `json:"tenant"`
-		TimeZone        *string         `json:"time_zone"`
-		TreeDepth       *int            `json:"tree_depth"`
-		URL             string          `json:"url"`
-		VMCount         int             `json:"virtual_machine_count"`
-		VLANCount       int             `json:"vlan_count"`
+		ID              uuid.UUID      `json:"id"`
+		ASN             *int           `json:"asn"`
+		CircuitCount    int            `json:"circuit_count"`
+		Comments        string         `json:"comments"`
+		ContactEmail    string         `json:"contact_email"`
+		ContactName     string         `json:"contact_name"`
+		ContactPhone    string         `json:"contact_phone"`
+		Created         time.Time      `json:"created"`
+		CustomFields    map[string]any `json:"custom_fields"`
+		Description     string         `json:"description"`
+		DeviceCount     int            `json:"device_count"`
+		Display         string         `json:"display"`
+		Facility        string         `json:"facility"`
+		LastUpdated     time.Time      `json:"last_updated"`
+		Latitude        *float64       `json:"latitude,string"`
+		LocationType    LocationType   `json:"location_type"`
+		Longitude       *float64       `json:"longitude,string"`
+		Name            string         `json:"name"`
+		NaturalSlug     string         `json:"natural_slug"`
+		NotesURL        string         `json:"notes_url"`
+		ObjectType      string         `json:"object_type"`
+		Parent          *Location      `json:"parent"`
+		PhysicalAddress string         `json:"physical_address"`
+		PrefixCount     int            `json:"prefix_count"`
+		RackCount       int            `json:"rack_count"`
+		ShippingAddress string         `json:"shipping_address"`
+		Status          types.Status   `json:"status"`
+		Tags            []types.Tag    `json:"tags"`
+		Tenant          *types.Tenant  `json:"tenant"`
+		TimeZone        *string        `json:"time_zone"`
+		TreeDepth       *int           `json:"tree_depth"`
+		URL             string         `json:"url"`
+		VMCount         int            `json:"virtual_machine_count"`
+		VLANCount       int            `json:"vlan_count"`
 	}
 
 	// NewLocation : Represents a new location to be created in Nautobot.

--- a/dcim/rack.go
+++ b/dcim/rack.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/neverbeencloser/gonautobot/core"
-	"github.com/neverbeencloser/gonautobot/tenancy"
 	"github.com/neverbeencloser/gonautobot/types"
 
 	"github.com/google/uuid"
@@ -42,7 +41,7 @@ type (
 		Serial         string              `json:"serial"`
 		Status         types.Status        `json:"status"`
 		Tags           []types.Tag         `json:"tags"`
-		Tenant         *tenancy.Tenant     `json:"tenant"`
+		Tenant         *types.Tenant       `json:"tenant"`
 		Type           *types.LabelValue   `json:"type"`
 		UHeight        int                 `json:"u_height"`
 		URL            string              `json:"url"`

--- a/examples/circuits.go
+++ b/examples/circuits.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"fmt"
-	"github.com/neverbeencloser/gonautobot/circuits"
-	"github.com/neverbeencloser/gonautobot/core"
-	"github.com/rs/zerolog/log"
 	"net/url"
+
+	"github.com/neverbeencloser/gonautobot/core"
+	"github.com/neverbeencloser/gonautobot/types"
+	"github.com/rs/zerolog/log"
 )
 
 // CircuitExample : Example usage of the Circuit Nautobot methods.
 func (c *ex) CircuitExample() {
-	r0, err := c.Circuits.CircuitCreate(circuits.CircuitRequest{
+	r0, err := c.Circuits.CircuitCreate(types.CircuitRequest{
 		CircuitID:   "abc12345903",
 		Status:      "Active",
 		Description: "Test Circuit",
@@ -26,7 +27,7 @@ func (c *ex) CircuitExample() {
 	if err != nil {
 		log.Fatal().Err(err)
 	}
-	first, _ := core.First[circuits.Circuit](r1)
+	first, _ := core.First[types.Circuit](r1)
 	fmt.Println(first.CircuitID)
 
 	r2, err := c.Circuits.CircuitGet(first.ID)

--- a/ipam/vrf.go
+++ b/ipam/vrf.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/dcim"
-	"github.com/neverbeencloser/gonautobot/tenancy"
 	"github.com/neverbeencloser/gonautobot/types"
 )
 
@@ -18,28 +17,28 @@ const (
 type (
 	// VRF : Data type entry for a VRF in Nautobot.
 	VRF struct {
-		ID                    uuid.UUID       `json:"id"`
-		Created               time.Time       `json:"created"`
-		CustomFields          map[string]any  `json:"custom_fields"`
-		Description           string          `json:"description"`
-		Devices               []dcim.Device   `json:"devices"`
-		Display               string          `json:"display"`
-		ExportTargets         []types.Object  `json:"export_targets"`
-		ImportTargets         []types.Object  `json:"import_targets"`
-		LastUpdated           time.Time       `json:"last_updated"`
-		Name                  string          `json:"name"`
-		Namespace             Namespace       `json:"namespace"`
-		NaturalSlug           string          `json:"natural_slug"`
-		NotesURL              string          `json:"notes_url"`
-		ObjectType            string          `json:"object_type"`
-		Prefixes              []Prefix        `json:"prefixes"`
-		RD                    string          `json:"rd"`
-		Status                *types.Status   `json:"status"`
-		Tags                  []types.Tag     `json:"tags"`
-		Tenant                *tenancy.Tenant `json:"tenant"`
-		URL                   string          `json:"url"`
-		VirtualDeviceContexts []types.Object  `json:"virtual_device_contexts"`
-		VirtualMachines       []types.Object  `json:"virtual_machines"`
+		ID                    uuid.UUID      `json:"id"`
+		Created               time.Time      `json:"created"`
+		CustomFields          map[string]any `json:"custom_fields"`
+		Description           string         `json:"description"`
+		Devices               []dcim.Device  `json:"devices"`
+		Display               string         `json:"display"`
+		ExportTargets         []types.Object `json:"export_targets"`
+		ImportTargets         []types.Object `json:"import_targets"`
+		LastUpdated           time.Time      `json:"last_updated"`
+		Name                  string         `json:"name"`
+		Namespace             Namespace      `json:"namespace"`
+		NaturalSlug           string         `json:"natural_slug"`
+		NotesURL              string         `json:"notes_url"`
+		ObjectType            string         `json:"object_type"`
+		Prefixes              []Prefix       `json:"prefixes"`
+		RD                    string         `json:"rd"`
+		Status                *types.Status  `json:"status"`
+		Tags                  []types.Tag    `json:"tags"`
+		Tenant                *types.Tenant  `json:"tenant"`
+		URL                   string         `json:"url"`
+		VirtualDeviceContexts []types.Object `json:"virtual_device_contexts"`
+		VirtualMachines       []types.Object `json:"virtual_machines"`
 	}
 
 	// NewVRF : Structured input for a new VRF record in Nautobot.

--- a/plugins/bgp/as.go
+++ b/plugins/bgp/as.go
@@ -7,43 +7,25 @@ import (
 
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
-	"github.com/neverbeencloser/gonautobot/types/nested"
-)
-
-type (
-	// AutonomousSystem : Autonomous System data struct representation.
-	AutonomousSystem struct {
-		ASN          int                    `json:"asn"`
-		Created      string                 `json:"created"`
-		CustomFields map[string]interface{} `json:"custom_fields"`
-		Description  string                 `json:"description"`
-		Display      string                 `json:"display"`
-		ID           string                 `json:"id"`
-		LastUpdated  string                 `json:"last_updated"`
-		Provider     *nested.Provider       `json:"provider"`
-		Status       *types.LabelValue      `json:"status"`
-		Tags         []types.Tag            `json:"tags"`
-		URL          string                 `json:"url"`
-	}
 )
 
 // BGPAutonomousSystemGet : Go function to process requests for the endpoint: /api/plugins/bgp/autonomous-systems/:id/
 //
 // https://demo.nautobot.com/api/docs/#/plugins/plugins_bgp_autonomous_systems_list
-func (c *Client) BGPAutonomousSystemGet(uuid string) (*AutonomousSystem, error) {
+func (c *Client) BGPAutonomousSystemGet(uuid string) (*types.AutonomousSystem, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("plugins/bgp/autonomous-systems/%s/", url.PathEscape(uuid)), nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := new(AutonomousSystem)
+	ret := new(types.AutonomousSystem)
 	return ret, c.UnmarshalDo(req, ret)
 }
 
 // BGPAutonomousSystemFilter : Go function to process requests for the endpoint: /api/plugins/bgp/autonomous-systems/
 //
 // https://demo.nautobot.com/api/docs/#/plugins/plugins_bgp_autonomous_systems_retrieve
-func (c *Client) BGPAutonomousSystemFilter(q *url.Values) ([]AutonomousSystem, error) {
-	resp := make([]AutonomousSystem, 0)
-	return resp, core.Paginate[AutonomousSystem](c.Client, "plugins/bgp/autonomous-systems/", q, &resp)
+func (c *Client) BGPAutonomousSystemFilter(q *url.Values) ([]types.AutonomousSystem, error) {
+	resp := make([]types.AutonomousSystem, 0)
+	return resp, core.Paginate[types.AutonomousSystem](c.Client, "plugins/bgp/autonomous-systems/", q, &resp)
 }

--- a/plugins/bgp/instance.go
+++ b/plugins/bgp/instance.go
@@ -7,39 +7,18 @@ import (
 
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
-	"github.com/neverbeencloser/gonautobot/types/nested"
-)
-
-type (
-	// RoutingInstance : Routing Instance data representation in Nautobot.
-	RoutingInstance struct {
-		AutonomousSystem *AutonomousSystem        `json:"autonomous_system"`
-		Created          string                   `json:"created"`
-		CustomFields     map[string]interface{}   `json:"custom_fields"`
-		Description      string                   `json:"description"`
-		Device           *nested.Device           `json:"device"`
-		Display          string                   `json:"display"`
-		Endpoints        []nested.BGPPeerEndpoint `json:"endpoints"`
-		ExtraAttributes  map[string]interface{}   `json:"extra_attributes"`
-		ID               string                   `json:"id"`
-		LastUpdated      string                   `json:"last_updated"`
-		RouterID         *nested.IPAddress        `json:"router_id"`
-		Status           *types.LabelValue        `json:"status"`
-		Tags             []types.Tag              `json:"tags"`
-		URL              string                   `json:"url"`
-	}
 )
 
 // BGPRoutingInstanceGet : Go function to process requests for the endpoint: /api/plugins/bgp/autonomous-systems/:id/
 //
 // https://demo.nautobot.com/api/docs/#/plugins/plugins_bgp_autonomous_systems_list
-func (c *Client) BGPRoutingInstanceGet(uuid string) (*RoutingInstance, error) {
+func (c *Client) BGPRoutingInstanceGet(uuid string) (*types.RoutingInstance, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("plugins/bgp/routing-instances/%s/", url.PathEscape(uuid)), nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := new(RoutingInstance)
+	ret := new(types.RoutingInstance)
 	err = c.UnmarshalDo(req, ret)
 	return ret, err
 }
@@ -47,7 +26,7 @@ func (c *Client) BGPRoutingInstanceGet(uuid string) (*RoutingInstance, error) {
 // BGPRoutingInstanceFilter : Go function to process requests for the endpoint: /api/plugins/bgp/autonomous-systems/
 //
 // https://demo.nautobot.com/api/docs/#/plugins/plugins_bgp_autonomous_systems_retrieve
-func (c *Client) BGPRoutingInstanceFilter(q *url.Values) ([]RoutingInstance, error) {
-	resp := make([]RoutingInstance, 0)
-	return resp, core.Paginate[RoutingInstance](c.Client, "plugins/bgp/routing-instances/", q, &resp)
+func (c *Client) BGPRoutingInstanceFilter(q *url.Values) ([]types.RoutingInstance, error) {
+	resp := make([]types.RoutingInstance, 0)
+	return resp, core.Paginate[types.RoutingInstance](c.Client, "plugins/bgp/routing-instances/", q, &resp)
 }

--- a/tenancy/tenant.go
+++ b/tenancy/tenant.go
@@ -2,7 +2,6 @@ package tenancy
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
@@ -13,69 +12,30 @@ const (
 	tenancyEndpointTenant = "tenancy/tenants/"
 )
 
-type (
-	// Tenant : defines a tenant entry in Nautobot
-	Tenant struct {
-		ID             uuid.UUID      `json:"id"`
-		CircuitCount   int            `json:"circuit_count"`
-		Comments       string         `json:"comments"`
-		Created        time.Time      `json:"created"`
-		CustomFields   map[string]any `json:"custom_fields"`
-		Description    string         `json:"description"`
-		DeviceCount    int            `json:"device_count"`
-		Display        string         `json:"display"`
-		IpaddressCount int            `json:"ipaddress_count"`
-		LastUpdated    time.Time      `json:"last_updated"`
-		Name           string         `json:"name"`
-		NaturalSlug    string         `json:"natural_slug"`
-		NotesURL       string         `json:"notes_url"`
-		ObjectType     string         `json:"object_type"`
-		PrefixCount    int            `json:"prefix_count"`
-		RackCount      int            `json:"rack_count"`
-		Tags           []types.Tag    `json:"tags"`
-		TenantGroup    *TenantGroup   `json:"tenant_group"`
-		URL            string         `json:"url"`
-		VMCount        int            `json:"virtualmachine_count"`
-		VlanCount      int            `json:"vlan_count"`
-		VrfCount       int            `json:"vrf_count"`
-	}
-
-	// NewTenant : defines a new tenant entry in Nautobot
-	NewTenant struct {
-		Name          string         `json:"name"`
-		Comments      string         `json:"comments,omitempty"`
-		CustomFields  map[string]any `json:"custom_fields,omitempty"`
-		Description   string         `json:"description,omitempty"`
-		Relationships map[string]any `json:"relationships,omitempty"`
-		TenantGroup   string         `json:"tenant_group,omitempty"`
-		Tags          []string       `json:"tags,omitempty"`
-	}
-)
-
 // TenantFilter : Go function to process requests for the endpoint: /api/tenancy/tenants/
 //
 // https://demo.nautobot.com/api/docs/#/tenancy/tenancy_tenants_list
-func (c *Client) TenantFilter(q *url.Values) ([]Tenant, error) {
-	resp := make([]Tenant, 0)
-	return resp, core.Paginate[Tenant](c.Client, tenancyEndpointTenant, q, &resp)
+func (c *Client) TenantFilter(q *url.Values) ([]types.Tenant, error) {
+	resp := make([]types.Tenant, 0)
+	return resp, core.Paginate[types.Tenant](c.Client, tenancyEndpointTenant, q, &resp)
 }
 
 // TenantAll : Go function to process requests for the endpoint: /api/tenancy/tenants/
 //
 // https://demo.nautobot.com/api/docs/#/tenancy/tenancy_tenants_list
-func (c *Client) TenantAll() ([]Tenant, error) {
-	resp := make([]Tenant, 0)
-	return resp, core.Paginate[Tenant](c.Client, tenancyEndpointTenant, nil, &resp)
+func (c *Client) TenantAll() ([]types.Tenant, error) {
+	resp := make([]types.Tenant, 0)
+	return resp, core.Paginate[types.Tenant](c.Client, tenancyEndpointTenant, nil, &resp)
 }
 
 // TenantGet : Get a Tenant by UUID identifier.
-func (c *Client) TenantGet(id uuid.UUID) (*Tenant, error) {
-	return core.Get[Tenant](c.Client, tenancyEndpointTenant, id)
+func (c *Client) TenantGet(id uuid.UUID) (*types.Tenant, error) {
+	return core.Get[types.Tenant](c.Client, tenancyEndpointTenant, id)
 }
 
 // TenantCreate : Generate a new Tenant record in Nautobot.
-func (c *Client) TenantCreate(obj NewTenant) (*Tenant, error) {
-	return core.Create[Tenant, NewTenant](c.Client, tenancyEndpointTenant, obj)
+func (c *Client) TenantCreate(obj types.NewTenant) (*types.Tenant, error) {
+	return core.Create[types.Tenant, types.NewTenant](c.Client, tenancyEndpointTenant, obj)
 }
 
 // TenantDelete : Delete a Tenant by UUID identifier.
@@ -84,6 +44,6 @@ func (c *Client) TenantDelete(id uuid.UUID) error {
 }
 
 // TenantUpdate : Update an existing Tenant record in Nautobot.
-func (c *Client) TenantUpdate(id uuid.UUID, patch map[string]any) (*Tenant, error) {
-	return core.Update[Tenant](c.Client, tenancyEndpointTenant, id, patch)
+func (c *Client) TenantUpdate(id uuid.UUID, patch map[string]any) (*types.Tenant, error) {
+	return core.Update[types.Tenant](c.Client, tenancyEndpointTenant, id, patch)
 }

--- a/tenancy/tenantgroup.go
+++ b/tenancy/tenantgroup.go
@@ -1,34 +1,16 @@
 package tenancy
 
 import (
-	"github.com/neverbeencloser/gonautobot/core"
 	"net/url"
-	"time"
-)
 
-type (
-	// TenantGroup : defines a tenant-group entry in Nautobot
-	TenantGroup struct {
-		ID           string         `json:"id"`
-		Display      string         `json:"display"`
-		URL          string         `json:"url"`
-		Name         string         `json:"name"`
-		Slug         string         `json:"slug"`
-		Parent       *TenantGroup   `json:"parent"`
-		Description  string         `json:"description"`
-		TenantCount  int            `json:"tenant_count"`
-		Depth        int            `json:"_depth"`
-		Created      string         `json:"created"`
-		LastUpdated  time.Time      `json:"last_updated"`
-		NotesURL     string         `json:"notes_url"`
-		CustomFields map[string]any `json:"custom_fields"`
-	}
+	"github.com/neverbeencloser/gonautobot/core"
+	"github.com/neverbeencloser/gonautobot/types"
 )
 
 // TenantGroupFilter : Go function to process requests for the endpoint: /api/tenancy/tenant-groups/
 //
 // https://demo.nautobot.com/api/docs/#/tenancy/tenancy_tenant_groups_list
-func (c *Client) TenantGroupFilter(q *url.Values) ([]TenantGroup, error) {
-	resp := make([]TenantGroup, 0)
-	return resp, core.Paginate[TenantGroup](c.Client, "tenancy/tenant-groups/", q, &resp)
+func (c *Client) TenantGroupFilter(q *url.Values) ([]types.TenantGroup, error) {
+	resp := make([]types.TenantGroup, 0)
+	return resp, core.Paginate[types.TenantGroup](c.Client, "tenancy/tenant-groups/", q, &resp)
 }

--- a/tests/tenancy_tenant_test.go
+++ b/tests/tenancy_tenant_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/tenancy"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -43,7 +43,7 @@ func TestClient_GetTenantGroups(t *testing.T) {
 }
 
 func TestClient_TenantCreate(t *testing.T) {
-	newTenant := tenancy.NewTenant{
+	newTenant := types.NewTenant{
 		Name: "Customer2",
 	}
 

--- a/types/circuits_circuit.go
+++ b/types/circuits_circuit.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"time"
+
+	"github.com/neverbeencloser/gonautobot/types/nested"
+)
+
+type (
+	// Circuit : defines a circuit entry in Nautobot
+	Circuit struct {
+		ID           string             `json:"id"`
+		Display      string             `json:"display"`
+		URL          string             `json:"url"`
+		CircuitID    string             `json:"cid"`
+		Provider     nested.Provider    `json:"provider"`
+		Type         nested.CircuitType `json:"type"`
+		Status       LabelValue         `json:"status"`
+		Tenant       nested.Tenant      `json:"tenant"`
+		InstallDate  string             `json:"install_date"`
+		CommitRate   int                `json:"commit_rate"`
+		Description  string             `json:"description"`
+		TerminationA Termination        `json:"termination_a"`
+		TerminationZ Termination        `json:"termination_z"`
+		Comments     string             `json:"comments"`
+		Created      string             `json:"created"`
+		LastUpdated  time.Time          `json:"last_updated"`
+		Tags         []Tag              `json:"tags"`
+		NotesURL     string             `json:"notes_url"`
+		CustomFields map[string]any     `json:"custom_fields"`
+	}
+
+	// CircuitRequest : Models a new circuit entry in Nautobot.
+	CircuitRequest struct {
+		CircuitID    string         `json:"cid"`
+		Provider     string         `json:"provider"`
+		Type         string         `json:"circuit_type"`
+		Status       string         `json:"status"`
+		Tenant       string         `json:"tenant,omitempty"`
+		InstallDate  string         `json:"install_date,omitempty"`
+		CommitRate   int            `json:"commit_rate,omitempty"`
+		Description  string         `json:"description,omitempty"`
+		TerminationA Termination    `json:"termination_a,omitempty"`
+		TerminationZ Termination    `json:"termination_z,omitempty"`
+		Comments     string         `json:"comments,omitempty"`
+		Created      string         `json:"created,omitempty"`
+		Tags         []Tag          `json:"tags,omitempty"`
+		CustomFields map[string]any `json:"custom_fields,omitempty"`
+	}
+)

--- a/types/circuits_provider.go
+++ b/types/circuits_provider.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"time"
+)
+
+type (
+	// Provider : defines a circuit provider in Nautobot
+	Provider struct {
+		ID           string         `json:"id"`
+		Display      string         `json:"display"`
+		URL          string         `json:"url"`
+		Name         string         `json:"name"`
+		Slug         string         `json:"slug"`
+		Asn          int            `json:"asn"`
+		Account      string         `json:"account"`
+		PortalURL    string         `json:"portal_url"`
+		NocContact   string         `json:"noc_contact"`
+		AdminContact string         `json:"admin_contact"`
+		Comments     string         `json:"comments"`
+		CircuitCount int            `json:"circuit_count"`
+		Created      string         `json:"created"`
+		LastUpdated  time.Time      `json:"last_updated"`
+		Tags         []Tag          `json:"tags"`
+		NotesURL     string         `json:"notes_url"`
+		CustomFields map[string]any `json:"custom_fields"`
+	}
+)

--- a/types/circuits_termination.go
+++ b/types/circuits_termination.go
@@ -1,4 +1,4 @@
-package circuits
+package types
 
 import (
 	"time"

--- a/types/plugins_bgp.go
+++ b/types/plugins_bgp.go
@@ -1,0 +1,38 @@
+package types
+
+import "github.com/neverbeencloser/gonautobot/types/nested"
+
+type (
+	// AutonomousSystem : Autonomous System data struct representation.
+	AutonomousSystem struct {
+		ASN          int                    `json:"asn"`
+		Created      string                 `json:"created"`
+		CustomFields map[string]interface{} `json:"custom_fields"`
+		Description  string                 `json:"description"`
+		Display      string                 `json:"display"`
+		ID           string                 `json:"id"`
+		LastUpdated  string                 `json:"last_updated"`
+		Provider     *nested.Provider       `json:"provider"`
+		Status       *LabelValue            `json:"status"`
+		Tags         []Tag                  `json:"tags"`
+		URL          string                 `json:"url"`
+	}
+
+	// RoutingInstance : Routing Instance data representation in Nautobot.
+	RoutingInstance struct {
+		AutonomousSystem *AutonomousSystem        `json:"autonomous_system"`
+		Created          string                   `json:"created"`
+		CustomFields     map[string]interface{}   `json:"custom_fields"`
+		Description      string                   `json:"description"`
+		Device           *nested.Device           `json:"device"`
+		Display          string                   `json:"display"`
+		Endpoints        []nested.BGPPeerEndpoint `json:"endpoints"`
+		ExtraAttributes  map[string]interface{}   `json:"extra_attributes"`
+		ID               string                   `json:"id"`
+		LastUpdated      string                   `json:"last_updated"`
+		RouterID         *nested.IPAddress        `json:"router_id"`
+		Status           *LabelValue              `json:"status"`
+		Tags             []Tag                    `json:"tags"`
+		URL              string                   `json:"url"`
+	}
+)

--- a/types/tenancy_tenant.go
+++ b/types/tenancy_tenant.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type (
+	// Tenant : defines a tenant entry in Nautobot
+	Tenant struct {
+		ID             uuid.UUID      `json:"id"`
+		CircuitCount   int            `json:"circuit_count"`
+		Comments       string         `json:"comments"`
+		Created        time.Time      `json:"created"`
+		CustomFields   map[string]any `json:"custom_fields"`
+		Description    string         `json:"description"`
+		DeviceCount    int            `json:"device_count"`
+		Display        string         `json:"display"`
+		IpaddressCount int            `json:"ipaddress_count"`
+		LastUpdated    time.Time      `json:"last_updated"`
+		Name           string         `json:"name"`
+		NaturalSlug    string         `json:"natural_slug"`
+		NotesURL       string         `json:"notes_url"`
+		ObjectType     string         `json:"object_type"`
+		PrefixCount    int            `json:"prefix_count"`
+		RackCount      int            `json:"rack_count"`
+		Tags           []Tag          `json:"tags"`
+		TenantGroup    *TenantGroup   `json:"tenant_group"`
+		URL            string         `json:"url"`
+		VMCount        int            `json:"virtualmachine_count"`
+		VlanCount      int            `json:"vlan_count"`
+		VrfCount       int            `json:"vrf_count"`
+	}
+
+	// NewTenant : defines a new tenant entry in Nautobot
+	NewTenant struct {
+		Name          string         `json:"name"`
+		Comments      string         `json:"comments,omitempty"`
+		CustomFields  map[string]any `json:"custom_fields,omitempty"`
+		Description   string         `json:"description,omitempty"`
+		Relationships map[string]any `json:"relationships,omitempty"`
+		TenantGroup   string         `json:"tenant_group,omitempty"`
+		Tags          []string       `json:"tags,omitempty"`
+	}
+)

--- a/types/tenancy_tenantgroup.go
+++ b/types/tenancy_tenantgroup.go
@@ -1,0 +1,22 @@
+package types
+
+import "time"
+
+type (
+	// TenantGroup : defines a tenant-group entry in Nautobot
+	TenantGroup struct {
+		ID           string         `json:"id"`
+		Display      string         `json:"display"`
+		URL          string         `json:"url"`
+		Name         string         `json:"name"`
+		Slug         string         `json:"slug"`
+		Parent       *TenantGroup   `json:"parent"`
+		Description  string         `json:"description"`
+		TenantCount  int            `json:"tenant_count"`
+		Depth        int            `json:"_depth"`
+		Created      string         `json:"created"`
+		LastUpdated  time.Time      `json:"last_updated"`
+		NotesURL     string         `json:"notes_url"`
+		CustomFields map[string]any `json:"custom_fields"`
+	}
+)

--- a/types/virtualization_cluster.go
+++ b/types/virtualization_cluster.go
@@ -1,10 +1,9 @@
-package virtualization
+package types
 
 import (
 	"time"
 
-	"github.com/neverbeencloser/gonautobot/dcim"
-	"github.com/neverbeencloser/gonautobot/tenancy"
+	"github.com/neverbeencloser/gonautobot/types/nested"
 )
 
 // Cluster : Cerebro Cluster data representation in Nautobot.
@@ -21,11 +20,11 @@ type Cluster struct {
 		ObjectType string `json:"object_type"`
 		URL        string `json:"url"`
 	} `json:"cluster_type"`
-	ClusterGroup any             `json:"cluster_group"`
-	Tenant       *tenancy.Tenant `json:"tenant"`
-	Location     *dcim.Location  `json:"location"`
-	Created      time.Time       `json:"created"`
-	LastUpdated  time.Time       `json:"last_updated"`
-	NotesURL     string          `json:"notes_url"`
-	CustomFields map[string]any  `json:"custom_fields"`
+	ClusterGroup any              `json:"cluster_group"`
+	Tenant       *Tenant          `json:"tenant"`
+	Location     *nested.Location `json:"location"`
+	Created      time.Time        `json:"created"`
+	LastUpdated  time.Time        `json:"last_updated"`
+	NotesURL     string           `json:"notes_url"`
+	CustomFields map[string]any   `json:"custom_fields"`
 }


### PR DESCRIPTION
## What
- refactor: moving all existing types into a flat types/ package
- in this PR: moving `circuits`, `bgp`, `tenancy` types

## Why
- to accurately model depth=1 queries, types need to be able to reference each other; the current layout is causing circular imports (e.g., dcim <-> ipam)