### PR TITLE
refactor: move ipam types into 'types' pkg

### DIFF
--- a/ipam/ip_address.go
+++ b/ipam/ip_address.go
@@ -7,73 +7,18 @@ import (
 
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
-	"github.com/neverbeencloser/gonautobot/types/nested"
-)
-
-type (
-	// IPAddress : defines an IP Address entry in Nautobot
-	//
-	// AssignedObject will need to be decoded dynamically based
-	// on the 'assigned_object_type', e.g., "dcim.interface"
-	IPAddress struct {
-		ID                 string                   `json:"id"`
-		Address            string                   `json:"address"`
-		AssignedObject     *AssignedObjectInterface `json:"assigned_object"`
-		AssignedObjectID   *string                  `json:"assigned_object_id"`
-		AssignedObjectType *string                  `json:"assigned_object_type"`
-		Created            string                   `json:"created"`
-		CustomFields       map[string]interface{}   `json:"custom_fields"`
-		Description        string                   `json:"description"`
-		Display            string                   `json:"display"`
-		DNSName            string                   `json:"dns_name"`
-		Family             *types.LabelValueInt     `json:"family"`
-		LastUpdated        string                   `json:"last_updated"`
-		NATInside          *string                  `json:"nat_inside"`
-		NATOutside         *string                  `json:"nat_outside"`
-		NotesURL           string                   `json:"notes_url"`
-		Role               *types.LabelValue        `json:"role"`
-		Status             *types.LabelValue        `json:"status"`
-		Tags               []types.Tag              `json:"tags"`
-		Tenant             *nested.Tenant           `json:"tenant"`
-		URL                string                   `json:"url"`
-		VRF                *nested.VRF              `json:"vrf"`
-	}
-
-	// AssignedObjectInterface : struct type for the `dcim.interface` and `virtualization.vminterface`
-	// assigned_object_type in the IPAddress struct.
-	// See below for available types:
-	// https://github.com/nautobot/nautobot/blob/v1.5.16/nautobot/ipam/constants.py#L35
-	AssignedObjectInterface struct {
-		Display string `json:"display"`
-		ID      string `json:"id"`
-		URL     string `json:"url"`
-		Device  struct {
-			Display string `json:"display"`
-			ID      string `json:"id"`
-			URL     string `json:"url"`
-			Name    string `json:"name"`
-		} `json:"device,omitempty"`
-		VirtualMachine struct {
-			Display string `json:"display"`
-			ID      string `json:"id"`
-			URL     string `json:"url"`
-			Name    string `json:"name"`
-		} `json:"virtual_machine,omitempty"`
-		Name  string `json:"name"`
-		Cable string `json:"cable"`
-	}
 )
 
 // IPAddressGet : Go function to process requests for the endpoint: /api/ipam/ip_addresses/:id/
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_ip_addresses_retrieve
-func (c *Client) IPAddressGet(uuid string) (*IPAddress, error) {
+func (c *Client) IPAddressGet(uuid string) (*types.IPAddress, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("ipam/ip-addresses/%s/", url.PathEscape(uuid)), nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := new(IPAddress)
+	ret := new(types.IPAddress)
 	err = c.UnmarshalDo(req, ret)
 	return ret, err
 }
@@ -81,7 +26,7 @@ func (c *Client) IPAddressGet(uuid string) (*IPAddress, error) {
 // IPAddressFilter : Go function to process requests for the endpoint: /api/ipam/ip_addresses/
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_ip_addresses_list
-func (c *Client) IPAddressFilter(q *url.Values) ([]IPAddress, error) {
-	resp := make([]IPAddress, 0)
-	return resp, core.Paginate[IPAddress](c.Client, "ipam/ip-addresses/", q, &resp)
+func (c *Client) IPAddressFilter(q *url.Values) ([]types.IPAddress, error) {
+	resp := make([]types.IPAddress, 0)
+	return resp, core.Paginate[types.IPAddress](c.Client, "ipam/ip-addresses/", q, &resp)
 }

--- a/ipam/namespace.go
+++ b/ipam/namespace.go
@@ -2,11 +2,9 @@ package ipam
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
-	"github.com/neverbeencloser/gonautobot/dcim"
 	"github.com/neverbeencloser/gonautobot/types"
 )
 
@@ -14,60 +12,31 @@ const (
 	ipamEndpointNamespace = "ipam/namespaces/"
 )
 
-type (
-	// Namespace : Represents a namespace in Nautobot.
-	Namespace struct {
-		ID           uuid.UUID      `json:"id"`
-		Created      time.Time      `json:"created"`
-		CustomFields map[string]any `json:"custom_fields"`
-		Description  string         `json:"description"`
-		Display      string         `json:"display"`
-		LastUpdated  time.Time      `json:"last_updated"`
-		Location     *dcim.Location `json:"location"`
-		Name         string         `json:"name"`
-		NaturalSlug  string         `json:"natural_slug"`
-		NotesURL     string         `json:"notes_url"`
-		ObjectType   string         `json:"object_type"`
-		Tags         []types.Tag    `json:"tags"`
-		URL          string         `json:"url"`
-	}
-
-	// NewNamespace : Represents a new namespace to be created in Nautobot.
-	NewNamespace struct {
-		Name          string         `json:"name"`
-		CustomFields  map[string]any `json:"custom_fields,omitempty"`
-		Description   string         `json:"description,omitempty"`
-		Location      string         `json:"location,omitempty"`
-		Relationships map[string]any `json:"relationships,omitempty"`
-		Tags          []string       `json:"tags,omitempty"`
-	}
-)
-
 // NamespaceGet : Get a Namespace by UUID identifier.
-func (c *Client) NamespaceGet(id uuid.UUID) (*Namespace, error) {
-	return core.Get[Namespace](c.Client, ipamEndpointNamespace, id)
+func (c *Client) NamespaceGet(id uuid.UUID) (*types.Namespace, error) {
+	return core.Get[types.Namespace](c.Client, ipamEndpointNamespace, id)
 }
 
 // NamespaceFilter : Get a list of Namespaces based on query parameters.
-func (c *Client) NamespaceFilter(q *url.Values) ([]Namespace, error) {
-	namespaces := make([]Namespace, 0)
-	return namespaces, core.Paginate[Namespace](c.Client, ipamEndpointNamespace, q, &namespaces)
+func (c *Client) NamespaceFilter(q *url.Values) ([]types.Namespace, error) {
+	namespaces := make([]types.Namespace, 0)
+	return namespaces, core.Paginate[types.Namespace](c.Client, ipamEndpointNamespace, q, &namespaces)
 }
 
 // NamespaceAll : Get all Namespaces in Nautobot.
-func (c *Client) NamespaceAll() ([]Namespace, error) {
-	namespaces := make([]Namespace, 0)
-	return namespaces, core.Paginate[Namespace](c.Client, ipamEndpointNamespace, nil, &namespaces)
+func (c *Client) NamespaceAll() ([]types.Namespace, error) {
+	namespaces := make([]types.Namespace, 0)
+	return namespaces, core.Paginate[types.Namespace](c.Client, ipamEndpointNamespace, nil, &namespaces)
 }
 
 // NamespaceCreate : Generate a new Namespace record in Nautobot.
-func (c *Client) NamespaceCreate(obj NewNamespace) (*Namespace, error) {
-	return core.Create[Namespace, NewNamespace](c.Client, ipamEndpointNamespace, obj)
+func (c *Client) NamespaceCreate(obj types.NewNamespace) (*types.Namespace, error) {
+	return core.Create[types.Namespace, types.NewNamespace](c.Client, ipamEndpointNamespace, obj)
 }
 
 // NamespaceUpdate : Update an existing Namespace record in Nautobot.
-func (c *Client) NamespaceUpdate(id uuid.UUID, patch map[string]any) (*Namespace, error) {
-	return core.Update[Namespace](c.Client, ipamEndpointNamespace, id, patch)
+func (c *Client) NamespaceUpdate(id uuid.UUID, patch map[string]any) (*types.Namespace, error) {
+	return core.Update[types.Namespace](c.Client, ipamEndpointNamespace, id, patch)
 }
 
 // NamespaceDelete : Delete a Namespace by UUID identifier.

--- a/ipam/prefix.go
+++ b/ipam/prefix.go
@@ -7,93 +7,18 @@ import (
 
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
-	"github.com/neverbeencloser/gonautobot/types/nested"
-)
-
-type (
-	// Prefix : defines an IPAM Prefix entry in Nautobot
-	Prefix struct {
-		Created      string                 `json:"created"`
-		CustomFields map[string]interface{} `json:"custom_fields"`
-		Description  string                 `json:"description"`
-		Display      string                 `json:"display"`
-		Family       *types.LabelValueInt   `json:"family"`
-		Group        *nested.SecretsGroup   `json:"group"`
-		ID           string                 `json:"id"`
-		IsPool       bool                   `json:"is_pool"`
-		LastUpdated  string                 `json:"last_updated"`
-		Location     *nested.Location       `json:"location"`
-		Name         string                 `json:"name"`
-		NotesURL     string                 `json:"notes_url"`
-		Prefix       string                 `json:"prefix"`
-		Role         *nested.Role           `json:"role"`
-		Site         *nested.Site           `json:"site"`
-		Status       *types.LabelValue      `json:"status"`
-		Tags         []types.Tag            `json:"tags"`
-		Tenant       *nested.Tenant         `json:"tenant"`
-		URL          string                 `json:"url"`
-		VLAN         *nested.VLAN           `json:"vlan"`
-		VRF          *nested.VRF            `json:"vrf"`
-	}
-
-	// PrefixAvailableIP : stub IPAddress entry returned by the /prefixes/:id/available-ips/ methods
-	PrefixAvailableIP struct {
-		Address string      `json:"address"`
-		Family  int         `json:"family"`
-		VRF     *nested.VRF `json:"vrf"`
-	}
-
-	// PrefixAvailablePrefix : stub Prefix entry returned by the /prefixes/:id/available-prefixes/ methods
-	PrefixAvailablePrefix struct {
-		Family int         `json:"family"`
-		Prefix string      `json:"prefix"`
-		VRF    *nested.VRF `json:"vrf"`
-	}
-
-	// NewPrefix : The data structure required to create a new Prefix object in Nautobot.
-	NewPrefix struct {
-		Description string      `json:"description"`
-		ID          string      `json:"id"`
-		IsPool      bool        `json:"is_pool"`
-		Prefix      string      `json:"prefix"`
-		Status      Status      `json:"status"`
-		Tags        []types.Tag `json:"tags"`
-		VRF         *nested.VRF `json:"vrf"`
-	}
-
-	// Status is a required parameter defining the status of the prefix ( enum)
-	Status string
-
-	// PrefixUpdate : defines writable fields to update a Prefix entry in nautobot
-	PrefixUpdate struct {
-		Prefix      string      `json:"prefix"`
-		IsPool      bool        `json:"is_pool"`
-		Tags        []types.Tag `json:"tags"`
-		Description string      `json:"description"`
-		VRF         *nested.VRF `json:"vrf"`
-		Site        string      `json:"site"`
-		Location    string      `json:"location"`
-		Tenant      string      `json:"tenant"`
-		VLAN        string      `json:"vlan"`
-	}
-
-	// PrefixesAvailablePrefixesCreateRequest : required parameters for PrefixesAvailablePrefixesCreate
-	PrefixesAvailablePrefixesCreateRequest struct {
-		PrefixLength int    `json:"prefix_length"`
-		Status       Status `json:"status"`
-	}
 )
 
 // PrefixGet : Go function to process requests for the endpoint: /api/ipam/prefixes/:id/
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_prefixes_retrieve
-func (c *Client) PrefixGet(uuid string) (*Prefix, error) {
+func (c *Client) PrefixGet(uuid string) (*types.Prefix, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("ipam/prefixes/%s/", url.PathEscape(uuid)), nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := new(Prefix)
+	ret := new(types.Prefix)
 	err = c.UnmarshalDo(req, ret)
 	return ret, err
 }
@@ -101,21 +26,21 @@ func (c *Client) PrefixGet(uuid string) (*Prefix, error) {
 // PrefixFilter : Go function to process requests for the endpoint: /api/ipam/prefixes/
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_prefixes_list
-func (c *Client) PrefixFilter(q *url.Values) ([]Prefix, error) {
-	resp := make([]Prefix, 0)
-	return resp, core.Paginate[Prefix](c.Client, "ipam/prefixes/", q, &resp)
+func (c *Client) PrefixFilter(q *url.Values) ([]types.Prefix, error) {
+	resp := make([]types.Prefix, 0)
+	return resp, core.Paginate[types.Prefix](c.Client, "ipam/prefixes/", q, &resp)
 }
 
 // PrefixCreate : Creates a new prefix using the NewPrefix data type.
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_prefixes_create
-func (c *Client) PrefixCreate(prefix *NewPrefix) (*Prefix, error) {
+func (c *Client) PrefixCreate(prefix *types.NewPrefix) (*types.Prefix, error) {
 	req, err := c.Request(http.MethodPost, "ipam/prefixes/", prefix, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var r Prefix
+	var r types.Prefix
 	err = c.UnmarshalDo(req, &r)
 	if err != nil {
 		return nil, fmt.Errorf("CreatePrefix.error.UnmarshalDo(%w)", err)
@@ -127,13 +52,13 @@ func (c *Client) PrefixCreate(prefix *NewPrefix) (*Prefix, error) {
 // PrefixUpdate : Updates a Nautobot prefix by UUID
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_prefixes_partial_update
-func (c *Client) PrefixUpdate(uuid string, prefix *PrefixUpdate) (*Prefix, error) {
+func (c *Client) PrefixUpdate(uuid string, prefix *types.PrefixUpdate) (*types.Prefix, error) {
 	req, err := c.Request(http.MethodPatch, fmt.Sprintf("ipam/prefixes/%s/", uuid), prefix, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var r Prefix
+	var r types.Prefix
 	if err := c.UnmarshalDo(req, &r); err != nil {
 		return nil, fmt.Errorf("UpdatePrefix.error.UnmarshalDo(%w)", err)
 	}
@@ -159,13 +84,13 @@ func (c *Client) PrefixDelete(prefixID string) error {
 // GetPrefixAvailableIPs : Go function to process requests for the endpoint: /api/ipam/prefixes/:id/available-ips/
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_prefixes_available_ips_list
-func (c *Client) GetPrefixAvailableIPs(uuid string, q *url.Values) ([]PrefixAvailableIP, error) {
+func (c *Client) GetPrefixAvailableIPs(uuid string, q *url.Values) ([]types.PrefixAvailableIP, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("ipam/prefixes/%s/available-ips/", url.PathEscape(uuid)), nil, q)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make([]PrefixAvailableIP, 0)
+	ret := make([]types.PrefixAvailableIP, 0)
 	if err := c.UnmarshalDo(req, &ret); err != nil {
 		return nil, fmt.Errorf("GetPrefixAvailableIPs.error.UnmarshalDo(%w)", err)
 	}
@@ -175,13 +100,13 @@ func (c *Client) GetPrefixAvailableIPs(uuid string, q *url.Values) ([]PrefixAvai
 // GetPrefixAvailablePrefixes : Go function to process requests for the endpoint: /api/ipam/prefixes/:id/available-prefixes/
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_prefixes_available_prefixes_list
-func (c *Client) GetPrefixAvailablePrefixes(uuid string, q *url.Values) ([]PrefixAvailablePrefix, error) {
+func (c *Client) GetPrefixAvailablePrefixes(uuid string, q *url.Values) ([]types.PrefixAvailablePrefix, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("ipam/prefixes/%s/available-prefixes/", url.PathEscape(uuid)), nil, q)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make([]PrefixAvailablePrefix, 0)
+	ret := make([]types.PrefixAvailablePrefix, 0)
 	if err := c.UnmarshalDo(req, &ret); err != nil {
 		return nil, fmt.Errorf("GetPrefixAvailablePrefixes.error.UnmarshalDo(%w)", err)
 	}

--- a/ipam/vlan.go
+++ b/ipam/vlan.go
@@ -7,49 +7,24 @@ import (
 
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
-	"github.com/neverbeencloser/gonautobot/types/nested"
-)
-
-type (
-	// VLAN : defines a vlan entry in Nautobot
-	VLAN struct {
-		ID           string                 `json:"id"`
-		Created      string                 `json:"created"`
-		CustomFields map[string]interface{} `json:"custom_fields"`
-		Description  string                 `json:"description"`
-		Display      string                 `json:"display"`
-		Group        *nested.SecretsGroup   `json:"group"`
-		LastUpdated  string                 `json:"last_updated"`
-		Location     *nested.Location       `json:"location"`
-		Name         string                 `json:"name"`
-		NotesURL     string                 `json:"notes_url"`
-		PrefixCount  int                    `json:"prefix_count"`
-		Role         *nested.Role           `json:"role"`
-		Site         *nested.Site           `json:"site"`
-		Status       *types.LabelValue      `json:"status"`
-		Tags         []types.Tag            `json:"tags"`
-		Tenant       *nested.Tenant         `json:"tenant"`
-		URL          string                 `json:"url"`
-		VID          int                    `json:"vid"`
-	}
 )
 
 // VLANGet : Go function to process requests for the endpoint: /api/ipam/vlans/:id/
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_vlans_retrieve
-func (c *Client) VLANGet(uuid string) (*VLAN, error) {
+func (c *Client) VLANGet(uuid string) (*types.VLAN, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("ipam/vlans/%s/", url.PathEscape(uuid)), nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	ret := new(VLAN)
+	ret := new(types.VLAN)
 	return ret, c.UnmarshalDo(req, ret)
 }
 
 // VLANFilter : Go function to process requests for the endpoint: /api/ipam/vlans/
 //
 // https://demo.nautobot.com/api/docs/#/ipam/ipam_vlans_list
-func (c *Client) VLANFilter(q *url.Values) ([]VLAN, error) {
-	resp := make([]VLAN, 0)
-	return resp, core.Paginate[VLAN](c.Client, "ipam/vlans/", q, &resp)
+func (c *Client) VLANFilter(q *url.Values) ([]types.VLAN, error) {
+	resp := make([]types.VLAN, 0)
+	return resp, core.Paginate[types.VLAN](c.Client, "ipam/vlans/", q, &resp)
 }

--- a/ipam/vrf.go
+++ b/ipam/vrf.go
@@ -2,11 +2,9 @@ package ipam
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
-	"github.com/neverbeencloser/gonautobot/dcim"
 	"github.com/neverbeencloser/gonautobot/types"
 )
 
@@ -14,69 +12,26 @@ const (
 	ipamEndpointVRF = "ipam/vrfs/"
 )
 
-type (
-	// VRF : Data type entry for a VRF in Nautobot.
-	VRF struct {
-		ID                    uuid.UUID      `json:"id"`
-		Created               time.Time      `json:"created"`
-		CustomFields          map[string]any `json:"custom_fields"`
-		Description           string         `json:"description"`
-		Devices               []dcim.Device  `json:"devices"`
-		Display               string         `json:"display"`
-		ExportTargets         []types.Object `json:"export_targets"`
-		ImportTargets         []types.Object `json:"import_targets"`
-		LastUpdated           time.Time      `json:"last_updated"`
-		Name                  string         `json:"name"`
-		Namespace             Namespace      `json:"namespace"`
-		NaturalSlug           string         `json:"natural_slug"`
-		NotesURL              string         `json:"notes_url"`
-		ObjectType            string         `json:"object_type"`
-		Prefixes              []Prefix       `json:"prefixes"`
-		RD                    string         `json:"rd"`
-		Status                *types.Status  `json:"status"`
-		Tags                  []types.Tag    `json:"tags"`
-		Tenant                *types.Tenant  `json:"tenant"`
-		URL                   string         `json:"url"`
-		VirtualDeviceContexts []types.Object `json:"virtual_device_contexts"`
-		VirtualMachines       []types.Object `json:"virtual_machines"`
-	}
-
-	// NewVRF : Structured input for a new VRF record in Nautobot.
-	NewVRF struct {
-		Name          string         `json:"name"`
-		Namespace     string         `json:"namespace"`
-		RD            string         `json:"rd"`
-		CustomFields  map[string]any `json:"custom_fields,omitempty"`
-		Description   string         `json:"description,omitempty"`
-		ExportTargets []string       `json:"export_targets,omitempty"`
-		ImportTargets []string       `json:"import_targets,omitempty"`
-		Relationships map[string]any `json:"relationships,omitempty"`
-		Status        string         `json:"status,omitempty"`
-		Tags          []string       `json:"tags,omitempty"`
-		Tenant        string         `json:"tenant,omitempty"`
-	}
-)
-
 // VRFGet : Get a VRF by UUID identifier.
-func (c *Client) VRFGet(id uuid.UUID) (*VRF, error) {
-	return core.Get[VRF](c.Client, ipamEndpointVRF, id)
+func (c *Client) VRFGet(id uuid.UUID) (*types.VRF, error) {
+	return core.Get[types.VRF](c.Client, ipamEndpointVRF, id)
 }
 
 // VRFFilter : Get a list of VRFs based on query parameters.
-func (c *Client) VRFFilter(q *url.Values) ([]VRF, error) {
-	vrfs := make([]VRF, 0)
-	return vrfs, core.Paginate[VRF](c.Client, ipamEndpointVRF, q, &vrfs)
+func (c *Client) VRFFilter(q *url.Values) ([]types.VRF, error) {
+	vrfs := make([]types.VRF, 0)
+	return vrfs, core.Paginate[types.VRF](c.Client, ipamEndpointVRF, q, &vrfs)
 }
 
 // VRFAll : Get all VRFs in Nautobot.
-func (c *Client) VRFAll() ([]VRF, error) {
-	vrfs := make([]VRF, 0)
-	return vrfs, core.Paginate[VRF](c.Client, ipamEndpointVRF, nil, &vrfs)
+func (c *Client) VRFAll() ([]types.VRF, error) {
+	vrfs := make([]types.VRF, 0)
+	return vrfs, core.Paginate[types.VRF](c.Client, ipamEndpointVRF, nil, &vrfs)
 }
 
 // VRFCreate : Generate a new VRF record in Nautobot.
-func (c *Client) VRFCreate(obj NewVRF) (*VRF, error) {
-	return core.Create[VRF, NewVRF](c.Client, ipamEndpointVRF, obj)
+func (c *Client) VRFCreate(obj types.NewVRF) (*types.VRF, error) {
+	return core.Create[types.VRF, types.NewVRF](c.Client, ipamEndpointVRF, obj)
 }
 
 // VRFDelete : Delete a VRF by UUID identifier.
@@ -85,6 +40,6 @@ func (c *Client) VRFDelete(id uuid.UUID) error {
 }
 
 // VRFUpdate : Update an existing VRF record in Nautobot.
-func (c *Client) VRFUpdate(id uuid.UUID, patch map[string]any) (*VRF, error) {
-	return core.Update[VRF](c.Client, ipamEndpointVRF, id, patch)
+func (c *Client) VRFUpdate(id uuid.UUID, patch map[string]any) (*types.VRF, error) {
+	return core.Update[types.VRF](c.Client, ipamEndpointVRF, id, patch)
 }

--- a/tests/ipam_namespace_test.go
+++ b/tests/ipam_namespace_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/ipam"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -65,7 +65,7 @@ func TestClient_NamespaceAll(t *testing.T) {
 func TestClient_NamespaceCreate(t *testing.T) {
 	defer gock.Off()
 
-	newNamespace := ipam.NewNamespace{
+	newNamespace := types.NewNamespace{
 		Name:        "Art old radio.",
 		Description: "",
 	}

--- a/tests/ipam_prefix_test.go
+++ b/tests/ipam_prefix_test.go
@@ -1,11 +1,12 @@
 package nautobot_test
 
 import (
-	"github.com/neverbeencloser/gonautobot/ipam"
-	"github.com/stretchr/testify/require"
 	"net/url"
 	"path"
 	"testing"
+
+	"github.com/neverbeencloser/gonautobot/types"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
@@ -48,7 +49,7 @@ func TestClient_GetPrefixAvailablePrefixes(t *testing.T) {
 }
 
 func TestClient_CreatePrefix(t *testing.T) {
-	req := ipam.NewPrefix{
+	req := types.NewPrefix{
 		Description: "Test Prefix",
 		IsPool:      false,
 		Prefix:      "10.197.27.0/29",

--- a/types/ipam_ipaddress.go
+++ b/types/ipam_ipaddress.go
@@ -1,0 +1,57 @@
+package types
+
+import "github.com/neverbeencloser/gonautobot/types/nested"
+
+type (
+	// IPAddress : defines an IP Address entry in Nautobot
+	//
+	// AssignedObject will need to be decoded dynamically based
+	// on the 'assigned_object_type', e.g., "dcim.interface"
+	IPAddress struct {
+		ID                 string                   `json:"id"`
+		Address            string                   `json:"address"`
+		AssignedObject     *AssignedObjectInterface `json:"assigned_object"`
+		AssignedObjectID   *string                  `json:"assigned_object_id"`
+		AssignedObjectType *string                  `json:"assigned_object_type"`
+		Created            string                   `json:"created"`
+		CustomFields       map[string]interface{}   `json:"custom_fields"`
+		Description        string                   `json:"description"`
+		Display            string                   `json:"display"`
+		DNSName            string                   `json:"dns_name"`
+		Family             *LabelValueInt           `json:"family"`
+		LastUpdated        string                   `json:"last_updated"`
+		NATInside          *string                  `json:"nat_inside"`
+		NATOutside         *string                  `json:"nat_outside"`
+		NotesURL           string                   `json:"notes_url"`
+		Role               *LabelValue              `json:"role"`
+		Status             *LabelValue              `json:"status"`
+		Tags               []Tag                    `json:"tags"`
+		Tenant             *nested.Tenant           `json:"tenant"`
+		URL                string                   `json:"url"`
+		VRF                *nested.VRF              `json:"vrf"`
+	}
+
+	// AssignedObjectInterface : struct type for the `dcim.interface` and `virtualization.vminterface`
+	// assigned_object_type in the IPAddress struct.
+	// See below for available types:
+	// https://github.com/nautobot/nautobot/blob/v1.5.16/nautobot/ipam/constants.py#L35
+	AssignedObjectInterface struct {
+		Display string `json:"display"`
+		ID      string `json:"id"`
+		URL     string `json:"url"`
+		Device  struct {
+			Display string `json:"display"`
+			ID      string `json:"id"`
+			URL     string `json:"url"`
+			Name    string `json:"name"`
+		} `json:"device,omitempty"`
+		VirtualMachine struct {
+			Display string `json:"display"`
+			ID      string `json:"id"`
+			URL     string `json:"url"`
+			Name    string `json:"name"`
+		} `json:"virtual_machine,omitempty"`
+		Name  string `json:"name"`
+		Cable string `json:"cable"`
+	}
+)

--- a/types/ipam_namespace.go
+++ b/types/ipam_namespace.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/neverbeencloser/gonautobot/types/nested"
+)
+
+type (
+	// Namespace : Represents a namespace in Nautobot.
+	Namespace struct {
+		ID           uuid.UUID        `json:"id"`
+		Created      time.Time        `json:"created"`
+		CustomFields map[string]any   `json:"custom_fields"`
+		Description  string           `json:"description"`
+		Display      string           `json:"display"`
+		LastUpdated  time.Time        `json:"last_updated"`
+		Location     *nested.Location `json:"location"`
+		Name         string           `json:"name"`
+		NaturalSlug  string           `json:"natural_slug"`
+		NotesURL     string           `json:"notes_url"`
+		ObjectType   string           `json:"object_type"`
+		Tags         []Tag            `json:"tags"`
+		URL          string           `json:"url"`
+	}
+
+	// NewNamespace : Represents a new namespace to be created in Nautobot.
+	NewNamespace struct {
+		Name          string         `json:"name"`
+		CustomFields  map[string]any `json:"custom_fields,omitempty"`
+		Description   string         `json:"description,omitempty"`
+		Location      string         `json:"location,omitempty"`
+		Relationships map[string]any `json:"relationships,omitempty"`
+		Tags          []string       `json:"tags,omitempty"`
+	}
+)

--- a/types/ipam_prefix.go
+++ b/types/ipam_prefix.go
@@ -1,0 +1,74 @@
+package types
+
+import "github.com/neverbeencloser/gonautobot/types/nested"
+
+type (
+	// Prefix : defines an IPAM Prefix entry in Nautobot
+	Prefix struct {
+		Created      string                 `json:"created"`
+		CustomFields map[string]interface{} `json:"custom_fields"`
+		Description  string                 `json:"description"`
+		Display      string                 `json:"display"`
+		Family       *LabelValueInt         `json:"family"`
+		Group        *nested.SecretsGroup   `json:"group"`
+		ID           string                 `json:"id"`
+		IsPool       bool                   `json:"is_pool"`
+		LastUpdated  string                 `json:"last_updated"`
+		Location     *nested.Location       `json:"location"`
+		Name         string                 `json:"name"`
+		NotesURL     string                 `json:"notes_url"`
+		Prefix       string                 `json:"prefix"`
+		Role         *nested.Role           `json:"role"`
+		Site         *nested.Site           `json:"site"`
+		Status       *LabelValue            `json:"status"`
+		Tags         []Tag                  `json:"tags"`
+		Tenant       *nested.Tenant         `json:"tenant"`
+		URL          string                 `json:"url"`
+		VLAN         *nested.VLAN           `json:"vlan"`
+		VRF          *nested.VRF            `json:"vrf"`
+	}
+
+	// PrefixAvailableIP : stub IPAddress entry returned by the /prefixes/:id/available-ips/ methods
+	PrefixAvailableIP struct {
+		Address string `json:"address"`
+		Family  int    `json:"family"`
+		VRF     *VRF   `json:"vrf"`
+	}
+
+	// PrefixAvailablePrefix : stub Prefix entry returned by the /prefixes/:id/available-prefixes/ methods
+	PrefixAvailablePrefix struct {
+		Family int    `json:"family"`
+		Prefix string `json:"prefix"`
+		VRF    *VRF   `json:"vrf"`
+	}
+
+	// NewPrefix : The data structure required to create a new Prefix object in Nautobot.
+	NewPrefix struct {
+		Description string `json:"description"`
+		ID          string `json:"id"`
+		IsPool      bool   `json:"is_pool"`
+		Prefix      string `json:"prefix"`
+		Status      string `json:"status"`
+		Tags        []Tag  `json:"tags"`
+		VRF         *VRF   `json:"vrf"`
+	}
+
+	// PrefixUpdate : defines writable fields to update a Prefix entry in nautobot
+	PrefixUpdate struct {
+		Prefix      string `json:"prefix"`
+		IsPool      bool   `json:"is_pool"`
+		Tags        []Tag  `json:"tags"`
+		Description string `json:"description"`
+		VRF         *VRF   `json:"vrf"`
+		Site        string `json:"site"`
+		Location    string `json:"location"`
+		Tenant      string `json:"tenant"`
+		VLAN        string `json:"vlan"`
+	}
+
+	// PrefixesAvailablePrefixesCreateRequest : required parameters for PrefixesAvailablePrefixesCreate
+	PrefixesAvailablePrefixesCreateRequest struct {
+		PrefixLength int    `json:"prefix_length"`
+		Status       Status `json:"status"`
+	}
+)

--- a/types/ipam_vlan.go
+++ b/types/ipam_vlan.go
@@ -1,0 +1,27 @@
+package types
+
+import "github.com/neverbeencloser/gonautobot/types/nested"
+
+type (
+	// VLAN : defines a vlan entry in Nautobot
+	VLAN struct {
+		ID           string                 `json:"id"`
+		Created      string                 `json:"created"`
+		CustomFields map[string]interface{} `json:"custom_fields"`
+		Description  string                 `json:"description"`
+		Display      string                 `json:"display"`
+		Group        *nested.SecretsGroup   `json:"group"`
+		LastUpdated  string                 `json:"last_updated"`
+		Location     *nested.Location       `json:"location"`
+		Name         string                 `json:"name"`
+		NotesURL     string                 `json:"notes_url"`
+		PrefixCount  int                    `json:"prefix_count"`
+		Role         *nested.Role           `json:"role"`
+		Site         *nested.Site           `json:"site"`
+		Status       *LabelValue            `json:"status"`
+		Tags         []Tag                  `json:"tags"`
+		Tenant       *nested.Tenant         `json:"tenant"`
+		URL          string                 `json:"url"`
+		VID          int                    `json:"vid"`
+	}
+)

--- a/types/ipam_vrf.go
+++ b/types/ipam_vrf.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/neverbeencloser/gonautobot/types/nested"
+)
+
+type (
+	// VRF : Data type entry for a VRF in Nautobot.
+	VRF struct {
+		ID                    uuid.UUID       `json:"id"`
+		Created               time.Time       `json:"created"`
+		CustomFields          map[string]any  `json:"custom_fields"`
+		Description           string          `json:"description"`
+		Devices               []nested.Device `json:"devices"`
+		Display               string          `json:"display"`
+		ExportTargets         []Object        `json:"export_targets"`
+		ImportTargets         []Object        `json:"import_targets"`
+		LastUpdated           time.Time       `json:"last_updated"`
+		Name                  string          `json:"name"`
+		Namespace             Namespace       `json:"namespace"`
+		NaturalSlug           string          `json:"natural_slug"`
+		NotesURL              string          `json:"notes_url"`
+		ObjectType            string          `json:"object_type"`
+		Prefixes              []Prefix        `json:"prefixes"`
+		RD                    string          `json:"rd"`
+		Status                *Status         `json:"status"`
+		Tags                  []Tag           `json:"tags"`
+		Tenant                *Tenant         `json:"tenant"`
+		URL                   string          `json:"url"`
+		VirtualDeviceContexts []Object        `json:"virtual_device_contexts"`
+		VirtualMachines       []Object        `json:"virtual_machines"`
+	}
+
+	// NewVRF : Structured input for a new VRF record in Nautobot.
+	NewVRF struct {
+		Name          string         `json:"name"`
+		Namespace     string         `json:"namespace"`
+		RD            string         `json:"rd"`
+		CustomFields  map[string]any `json:"custom_fields,omitempty"`
+		Description   string         `json:"description,omitempty"`
+		ExportTargets []string       `json:"export_targets,omitempty"`
+		ImportTargets []string       `json:"import_targets,omitempty"`
+		Relationships map[string]any `json:"relationships,omitempty"`
+		Status        string         `json:"status,omitempty"`
+		Tags          []string       `json:"tags,omitempty"`
+		Tenant        string         `json:"tenant,omitempty"`
+	}
+)


### PR DESCRIPTION
### What
 - refactor: moving all existing types into a flat `types/` package
 - in this PR: moving `ipam` types into `types` pkg

### Why
 - to accurately model `depth=1` queries, types need to be able to reference each other; the current layout is causing circular imports (e.g., dcim <-> ipam)
