### PR TITLE
refactor: move dcim types into 'types' pkg

### DIFF
--- a/dcim/console.go
+++ b/dcim/console.go
@@ -11,56 +11,15 @@ import (
 	"github.com/neverbeencloser/gonautobot/types"
 )
 
-type (
-	// ConsolePort : Data representation of a Console Port in Nautobot.
-	ConsolePort struct {
-		ID           string                 `json:"id"`
-		URL          string                 `json:"url"`
-		CustomFields map[string]interface{} `json:"custom_fields"`
-		Device       struct {
-			ID          string `json:"id"`
-			URL         string `json:"url"`
-			Name        string `json:"name"`
-			DisplayName string `json:"display_name"`
-		} `json:"device"`
-		Name                  string            `json:"name"`
-		Label                 string            `json:"label"`
-		Description           string            `json:"description"`
-		ConnectedEndpointType string            `json:"connected_endpoint_type"`
-		ConnectedEndpoint     ConnectedEndpoint `json:"connected_endpoint"`
-		Cable                 struct {
-			ID    string `json:"id"`
-			URL   string `json:"url"`
-			Label string `json:"label"`
-		} `json:"cable"`
-		Tags []types.Tag `json:"tags"`
-	}
-
-	// ConnectedEndpoint : Struct representing the far-side of the console connection.
-	ConnectedEndpoint struct {
-		ID     string `json:"id"`
-		URL    string `json:"url"`
-		Device struct {
-			ID          string `json:"id"`
-			URL         string `json:"url"`
-			Name        string `json:"name"`
-			DisplayName string `json:"display_name"`
-		} `json:"device"`
-		Name  string `json:"name"`
-		Cable string `json:"cable"`
-		Port  int
-	}
-)
-
 // ConsoleConnectionFilter : Method used to fetch a list of console connections for a device.
-func (c *Client) ConsoleConnectionFilter(q *url.Values) ([]ConsolePort, error) {
+func (c *Client) ConsoleConnectionFilter(q *url.Values) ([]types.ConsolePort, error) {
 	req, err := c.Request(http.MethodGet, "dcim/console-connections/", nil, q)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := new(types.ResponseList)
-	ret := make([]ConsolePort, 0)
+	ret := make([]types.ConsolePort, 0)
 	if err = c.UnmarshalDo(req, resp); err != nil {
 		return ret, err
 	}

--- a/dcim/device.go
+++ b/dcim/device.go
@@ -8,91 +8,18 @@ import (
 
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
-	"github.com/neverbeencloser/gonautobot/types/nested"
-)
-
-type (
-	// Device : Data structure to represent a device record in Nautobot.
-	Device struct {
-		ID                 string                        `json:"id"`
-		AssetTag           string                        `json:"asset_tag"`
-		Cluster            *nested.VirtualizationCluster `json:"cluster"`
-		Comments           string                        `json:"comments" datastore:",noindex"`
-		ConfigContext      map[string]interface{}        `json:"config_context"`
-		Created            string                        `json:"created"`
-		CustomFields       map[string]interface{}        `json:"custom_fields"`
-		DeviceRole         *nested.DeviceRole            `json:"device_role"`
-		DeviceType         *nested.DeviceType            `json:"device_type"`
-		Display            string                        `json:"display"`
-		Face               *types.LabelValue             `json:"face"`
-		LastUpdated        string                        `json:"last_updated"`
-		LocalContextSchema *nested.ConfigContextSchema   `json:"local_context_schema"`
-		LocalContextData   map[string]interface{}        `json:"local_context_data"`
-		Location           *nested.Location              `json:"location"`
-		Name               string                        `json:"name"`
-		NotesURL           string                        `json:"notes_url"`
-		ParentDevice       *Device                       `json:"parent_device"`
-		Platform           *nested.Platform              `json:"platform"`
-		Position           *int                          `json:"position"`
-		PrimaryIP          *nested.IPAddress             `json:"primary_ip"`
-		PrimaryIP4         *nested.IPAddress             `json:"primary_ip4"`
-		PrimaryIP6         *nested.IPAddress             `json:"primary_ip6"`
-		Rack               *nested.Rack                  `json:"rack"`
-		SecretsGroup       *nested.SecretsGroup          `json:"secrets_group"`
-		Serial             string                        `json:"serial"`
-		Site               *Site                         `json:"site"`
-		Status             *types.LabelValue             `json:"status"`
-		Tags               []types.Tag                   `json:"tags"`
-		Tenant             *nested.Tenant                `json:"tenant"`
-		URL                string                        `json:"url"`
-		VCPosition         *int                          `json:"vc_position"`
-		VCPriority         *int                          `json:"vc_priority"`
-		VirtualChassis     *nested.VirtualChassis        `json:"virtual_chassis"`
-	}
-
-	// NewDevice : Structured input for a new Device record in Nautobot.
-	NewDevice struct {
-		Name                         string         `json:"name"`
-		Role                         string         `json:"role"`
-		Status                       string         `json:"status"`
-		DeviceType                   string         `json:"device_type"`
-		Location                     string         `json:"location,omitempty"`
-		Site                         string         `json:"site,omitempty"`
-		Tenant                       string         `json:"tenant,omitempty"`
-		Platform                     string         `json:"platform,omitempty"`
-		Serial                       string         `json:"serial,omitempty"`
-		AssetTag                     string         `json:"asset_tag,omitempty"`
-		Position                     int            `json:"position,omitempty"`
-		Face                         string         `json:"face,omitempty"`
-		VcPosition                   int            `json:"vc_position,omitempty"`
-		VcPriority                   int            `json:"vc_priority,omitempty"`
-		Comments                     string         `json:"comments,omitempty"`
-		Rack                         string         `json:"rack,omitempty"`
-		PrimaryIP4                   string         `json:"primary_ip4,omitempty"`
-		PrimaryIP6                   string         `json:"primary_ip6,omitempty"`
-		Cluster                      string         `json:"cluster,omitempty"`
-		VirtualChassis               string         `json:"virtual_chassis,omitempty"`
-		DeviceRedundancyGroup        string         `json:"device_redundancy_group,omitempty"`
-		SoftwareVersion              string         `json:"software_version,omitempty"`
-		SecretsGroup                 string         `json:"secrets_group,omitempty"`
-		ControllerManagedDeviceGroup string         `json:"controller_managed_device_group,omitempty"`
-		SoftwareImageFiles           []string       `json:"software_image_files,omitempty"`
-		CustomFields                 map[string]any `json:"custom_fields,omitempty"`
-		Tags                         []string       `json:"tags,omitempty"`
-		ParentBay                    string         `json:"parent_bay,omitempty"`
-	}
 )
 
 // DeviceGet : Go function to process requests for the endpoint: /api/dcim/devices/:id/
 //
 // https://demo.nautobot.com/api/docs/#/dcim/dcim_devices_retrieve
-func (c *Client) DeviceGet(uuid string) (*Device, error) {
+func (c *Client) DeviceGet(uuid string) (*types.Device, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("dcim/devices/%s/", url.PathEscape(uuid)), nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := new(Device)
+	ret := new(types.Device)
 	err = c.UnmarshalDo(req, ret)
 	return ret, err
 }
@@ -100,22 +27,22 @@ func (c *Client) DeviceGet(uuid string) (*Device, error) {
 // DeviceFilter : Go function to process requests for the endpoint: /api/dcim/devices/
 //
 // https://demo.nautobot.com/api/docs/#/dcim/dcim_devices_list
-func (c *Client) DeviceFilter(q *url.Values) ([]Device, error) {
-	devices := make([]Device, 0)
-	return devices, core.Paginate[Device](c.Client, "dcim/devices/", q, &devices)
+func (c *Client) DeviceFilter(q *url.Values) ([]types.Device, error) {
+	devices := make([]types.Device, 0)
+	return devices, core.Paginate[types.Device](c.Client, "dcim/devices/", q, &devices)
 }
 
 // DeviceAll : Go function to process requests for the endpoint: /api/dcim/devices/
 //
 // https://demo.nautobot.com/api/docs/#/dcim/dcim_devices_list
-func (c *Client) DeviceAll() ([]Device, error) {
-	devices := make([]Device, 0)
-	return devices, core.Paginate[Device](c.Client, "dcim/devices/", nil, &devices)
+func (c *Client) DeviceAll() ([]types.Device, error) {
+	devices := make([]types.Device, 0)
+	return devices, core.Paginate[types.Device](c.Client, "dcim/devices/", nil, &devices)
 }
 
 // DeviceCreate : Generate a new Device record in Nautobot.
-func (c *Client) DeviceCreate(obj NewDevice) (Device, error) {
-	var r Device
+func (c *Client) DeviceCreate(obj types.NewDevice) (types.Device, error) {
+	var r types.Device
 	req, err := c.Request(http.MethodPost, "dcim/devices/", obj, nil)
 	if err != nil {
 		return r, err
@@ -140,8 +67,8 @@ func (c *Client) DeviceDelete(uuid string) error {
 }
 
 // DeviceUpdate : Update an existing Device record in Nautobot.
-func (c *Client) DeviceUpdate(uuid string, patch map[string]any) (Device, error) {
-	var r Device
+func (c *Client) DeviceUpdate(uuid string, patch map[string]any) (types.Device, error) {
+	var r types.Device
 	req, err := c.Request(http.MethodPatch, fmt.Sprintf("dcim/devices/%s/", uuid), patch, nil)
 	if err != nil {
 		return r, err

--- a/dcim/devicefamily.go
+++ b/dcim/devicefamily.go
@@ -2,7 +2,6 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
@@ -13,52 +12,26 @@ const (
 	dcimEndpointDeviceFamily = "dcim/device-families/"
 )
 
-type (
-	// DeviceFamily represents a device family in Nautobot's DCIM module.
-	DeviceFamily struct {
-		ID           uuid.UUID      `json:"id"`
-		Created      time.Time      `json:"created"`
-		CustomFields map[string]any `json:"custom_fields"`
-		Description  string         `json:"description"`
-		Display      string         `json:"display"`
-		LastUpdated  time.Time      `json:"last_updated"`
-		Name         string         `json:"name"`
-		NaturalSlug  string         `json:"natural_slug"`
-		NotesURL     string         `json:"notes_url"`
-		ObjectType   string         `json:"object_type"`
-		Tags         []types.Tag    `json:"tags"`
-		URL          string         `json:"url"`
-	}
-
-	// NewDeviceFamily represents the data required to create a new device family.
-	NewDeviceFamily struct {
-		Name         string         `json:"name"`
-		CustomFields map[string]any `json:"custom_fields,omitempty"`
-		Description  string         `json:"description,omitempty"`
-		Tags         []string       `json:"tags,omitempty"`
-	}
-)
-
 // DeviceFamilyGet : Get a DeviceFamily by UUID identifier.
-func (c *Client) DeviceFamilyGet(id uuid.UUID) (*DeviceFamily, error) {
-	return core.Get[DeviceFamily](c.Client, dcimEndpointDeviceFamily, id)
+func (c *Client) DeviceFamilyGet(id uuid.UUID) (*types.DeviceFamily, error) {
+	return core.Get[types.DeviceFamily](c.Client, dcimEndpointDeviceFamily, id)
 }
 
 // DeviceFamilyFilter : Get a list of DeviceFamilies based on query parameters.
-func (c *Client) DeviceFamilyFilter(q *url.Values) ([]DeviceFamily, error) {
-	deviceFamilies := make([]DeviceFamily, 0)
-	return deviceFamilies, core.Paginate[DeviceFamily](c.Client, dcimEndpointDeviceFamily, q, &deviceFamilies)
+func (c *Client) DeviceFamilyFilter(q *url.Values) ([]types.DeviceFamily, error) {
+	deviceFamilies := make([]types.DeviceFamily, 0)
+	return deviceFamilies, core.Paginate[types.DeviceFamily](c.Client, dcimEndpointDeviceFamily, q, &deviceFamilies)
 }
 
 // DeviceFamilyAll : Get all DeviceFamilies in Nautobot.
-func (c *Client) DeviceFamilyAll() ([]DeviceFamily, error) {
-	deviceFamilies := make([]DeviceFamily, 0)
-	return deviceFamilies, core.Paginate[DeviceFamily](c.Client, dcimEndpointDeviceFamily, nil, &deviceFamilies)
+func (c *Client) DeviceFamilyAll() ([]types.DeviceFamily, error) {
+	deviceFamilies := make([]types.DeviceFamily, 0)
+	return deviceFamilies, core.Paginate[types.DeviceFamily](c.Client, dcimEndpointDeviceFamily, nil, &deviceFamilies)
 }
 
 // DeviceFamilyCreate : Generate a new DeviceFamily record in Nautobot.
-func (c *Client) DeviceFamilyCreate(obj NewDeviceFamily) (*DeviceFamily, error) {
-	return core.Create[DeviceFamily, NewDeviceFamily](c.Client, dcimEndpointDeviceFamily, obj)
+func (c *Client) DeviceFamilyCreate(obj types.NewDeviceFamily) (*types.DeviceFamily, error) {
+	return core.Create[types.DeviceFamily, types.NewDeviceFamily](c.Client, dcimEndpointDeviceFamily, obj)
 }
 
 // DeviceFamilyDelete : Delete a DeviceFamily by UUID identifier.
@@ -67,6 +40,6 @@ func (c *Client) DeviceFamilyDelete(id uuid.UUID) error {
 }
 
 // DeviceFamilyUpdate : Update an existing DeviceFamily record in Nautobot.
-func (c *Client) DeviceFamilyUpdate(id uuid.UUID, patch map[string]any) (*DeviceFamily, error) {
-	return core.Update[DeviceFamily](c.Client, dcimEndpointDeviceFamily, id, patch)
+func (c *Client) DeviceFamilyUpdate(id uuid.UUID, patch map[string]any) (*types.DeviceFamily, error) {
+	return core.Update[types.DeviceFamily](c.Client, dcimEndpointDeviceFamily, id, patch)
 }

--- a/dcim/devicetype.go
+++ b/dcim/devicetype.go
@@ -2,7 +2,6 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
@@ -13,73 +12,26 @@ const (
 	dcimEndpointDeviceType = "dcim/device-types/"
 )
 
-type (
-	// DeviceType represents a device type in Nautobot.
-	DeviceType struct {
-		ID                 uuid.UUID           `json:"id"`
-		Comments           string              `json:"comments"`
-		Created            time.Time           `json:"created"`
-		CustomFields       map[string]any      `json:"custom_fields"`
-		DeviceCount        int                 `json:"device_count"`
-		DeviceFamily       *DeviceFamily       `json:"device_family"`
-		Display            string              `json:"display"`
-		FrontImage         *string             `json:"front_image"`
-		IsFullDepth        bool                `json:"is_full_depth"`
-		LastUpdated        time.Time           `json:"last_updated"`
-		Manufacturer       *Manufacturer       `json:"manufacturer"`
-		Model              string              `json:"model"`
-		NaturalSlug        string              `json:"natural_slug"`
-		NotesURL           string              `json:"notes_url"`
-		ObjectType         string              `json:"object_type"`
-		PartNumber         string              `json:"part_number"`
-		RearImage          *string             `json:"rear_image"`
-		SoftwareImageFiles []SoftwareImageFile `json:"software_image_files"`
-		SubDeviceRole      *types.LabelValue   `json:"subdevice_role"`
-		Tags               []types.Tag         `json:"tags"`
-		UHeight            int                 `json:"u_height"`
-		URL                string              `json:"url"`
-	}
-
-	// NewDeviceType represents the structure for creating a new DeviceType in Nautobot.
-	//
-	// It uses our internal 'form' tags for generating multipart/form-data requests.
-	NewDeviceType struct {
-		Manufacturer       string         `form:"manufacturer"`
-		Model              string         `form:"model"`
-		Comments           string         `form:"comments"`
-		CustomFields       map[string]any `form:"custom_fields,omitempty"`
-		DeviceFamily       string         `form:"device_family"`
-		FrontImage         *string        `form:"front_image,omitempty,upload"`
-		IsFullDepth        bool           `form:"is_full_depth"`
-		PartNumber         string         `form:"part_number"`
-		RearImage          *string        `form:"rear_image,omitempty,upload"`
-		SoftwareImageFiles []string       `form:"software_image_files,omitempty"`
-		SubDeviceRole      string         `form:"subdevice_role"`
-		Tags               []string       `form:"tags,omitempty"`
-		UHeight            int            `form:"u_height"`
-	}
-)
-
 // DeviceTypeGet : Get a DeviceType by UUID identifier.
-func (c *Client) DeviceTypeGet(id uuid.UUID) (*DeviceType, error) {
-	return core.Get[DeviceType](c.Client, dcimEndpointDeviceType, id)
+func (c *Client) DeviceTypeGet(id uuid.UUID) (*types.DeviceType, error) {
+	return core.Get[types.DeviceType](c.Client, dcimEndpointDeviceType, id)
 }
 
 // DeviceTypeFilter : Get a list of DeviceTypes based on query parameters.
-func (c *Client) DeviceTypeFilter(q *url.Values) ([]DeviceType, error) {
-	devicetypes := make([]DeviceType, 0)
-	return devicetypes, core.Paginate[DeviceType](c.Client, dcimEndpointDeviceType, q, &devicetypes)
+func (c *Client) DeviceTypeFilter(q *url.Values) ([]types.DeviceType, error) {
+	devicetypes := make([]types.DeviceType, 0)
+	return devicetypes, core.Paginate[types.DeviceType](c.Client, dcimEndpointDeviceType, q, &devicetypes)
 }
 
 // DeviceTypeAll : Get all DeviceTypes in Nautobot.
-func (c *Client) DeviceTypeAll() ([]DeviceType, error) {
-	devicetypes := make([]DeviceType, 0)
-	return devicetypes, core.Paginate[DeviceType](c.Client, dcimEndpointDeviceType, nil, &devicetypes)
+func (c *Client) DeviceTypeAll() ([]types.DeviceType, error) {
+	devicetypes := make([]types.DeviceType, 0)
+	return devicetypes, core.Paginate[types.DeviceType](c.Client, dcimEndpointDeviceType, nil, &devicetypes)
 }
 
 // DeviceTypeCreate : Generate a new DeviceType record in Nautobot.
-func (c *Client) DeviceTypeCreate(obj NewDeviceType) (*DeviceType, error) {
-	return core.CreateMultipart[DeviceType, NewDeviceType](c.Client, dcimEndpointDeviceType, obj)
+func (c *Client) DeviceTypeCreate(obj types.NewDeviceType) (*types.DeviceType, error) {
+	return core.CreateMultipart[types.DeviceType, types.NewDeviceType](c.Client, dcimEndpointDeviceType, obj)
 }
 
 // DeviceTypeDelete : Delete a DeviceType by UUID identifier.
@@ -88,16 +40,6 @@ func (c *Client) DeviceTypeDelete(id uuid.UUID) error {
 }
 
 // DeviceTypeUpdate : Update an existing DeviceType record in Nautobot.
-func (c *Client) DeviceTypeUpdate(id uuid.UUID, obj NewDeviceType) (*DeviceType, error) {
-	return core.UpdateMultipart[DeviceType, NewDeviceType](c.Client, dcimEndpointDeviceType, id, obj)
-}
-
-// SetFrontImage is a convenience method to set the front image path for a NewDeviceType.
-func (n *NewDeviceType) SetFrontImage(path string) {
-	n.FrontImage = &path
-}
-
-// SetRearImage is a convenience method to set the rear image path for a NewDeviceType.
-func (n *NewDeviceType) SetRearImage(path string) {
-	n.RearImage = &path
+func (c *Client) DeviceTypeUpdate(id uuid.UUID, obj types.NewDeviceType) (*types.DeviceType, error) {
+	return core.UpdateMultipart[types.DeviceType, types.NewDeviceType](c.Client, dcimEndpointDeviceType, id, obj)
 }

--- a/dcim/interface.go
+++ b/dcim/interface.go
@@ -1,65 +1,24 @@
 package dcim
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
-	"github.com/neverbeencloser/gonautobot/types/nested"
-)
-
-type (
-	// Interface : defines an interface as represented in Nautobot
-	//
-	// CablePeer and ConnectedEndpoint must be decoded dynamically; they are dependent
-	// on the value of 'CablePeerType' and 'ConnectedEndpointType', e.g., "dcim.interface"
-	Interface struct {
-		ID                         string                 `json:"id"`
-		Bridge                     *Interface             `json:"bridge"`
-		Cable                      *nested.Cable          `json:"cable"`
-		CablePeer                  json.RawMessage        `json:"cable_peer"`
-		CablePeerType              *string                `json:"cable_peer_type"`
-		ConnectedEndpoint          json.RawMessage        `json:"connected_endpoint"`
-		ConnectedEndpointReachable bool                   `json:"connected_endpoint_reachable"`
-		ConnectedEndpointType      *string                `json:"connected_endpoint_type"`
-		CountIPAddresses           int                    `json:"count_ipaddresses"`
-		Created                    string                 `json:"created"`
-		CustomFields               map[string]interface{} `json:"custom_fields"`
-		Description                string                 `json:"description"`
-		Device                     *Device                `json:"device"`
-		Display                    string                 `json:"display"`
-		Enabled                    bool                   `json:"enabled"`
-		Label                      string                 `json:"label"`
-		Lag                        *Interface             `json:"lag"`
-		LastUpdated                string                 `json:"last_updated"`
-		MACAddress                 *string                `json:"mac_address"`
-		MgmtOnly                   bool                   `json:"mgmt_only"`
-		Mode                       *types.LabelValue      `json:"mode"`
-		MTU                        *int                   `json:"mtu"`
-		Name                       string                 `json:"name"`
-		NotesURL                   string                 `json:"notes_url"`
-		ParentInterface            *Interface             `json:"parent_interface"`
-		TaggedVLANs                []nested.VLAN          `json:"tagged_vlans"`
-		Tags                       []types.Tag            `json:"tags"`
-		Type                       *types.LabelValue      `json:"type"`
-		UntaggedVLAN               *nested.VLAN           `json:"untagged_vlan"`
-		URL                        string                 `json:"url"`
-	}
 )
 
 // InterfaceGet : Go function to process requests for the endpoint: /api/dcim/interfaces/:id/
 //
 // https://demo.nautobot.com/api/docs/#/dcim/dcim_interfaces_retrieve
-func (c *Client) InterfaceGet(uuid string) (*Interface, error) {
+func (c *Client) InterfaceGet(uuid string) (*types.DeviceInterface, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("dcim/interfaces/%s/", url.PathEscape(uuid)), nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := new(Interface)
+	ret := new(types.DeviceInterface)
 	err = c.UnmarshalDo(req, ret)
 	return ret, err
 }
@@ -67,9 +26,9 @@ func (c *Client) InterfaceGet(uuid string) (*Interface, error) {
 // InterfaceFilter : Go function to process requests for the endpoint: /api/dcim/interfaces/
 //
 // https://demo.nautobot.com/api/docs/#/dcim/dcim_interfaces_list
-func (c *Client) InterfaceFilter(q *url.Values) ([]Interface, error) {
-	resp := make([]Interface, 0)
-	if err := core.Paginate[Interface](c.Client, "dcim/interfaces/", q, &resp); err != nil {
+func (c *Client) InterfaceFilter(q *url.Values) ([]types.DeviceInterface, error) {
+	resp := make([]types.DeviceInterface, 0)
+	if err := core.Paginate[types.DeviceInterface](c.Client, "dcim/interfaces/", q, &resp); err != nil {
 		return nil, err
 	}
 	return resp, nil

--- a/dcim/location.go
+++ b/dcim/location.go
@@ -2,7 +2,6 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
@@ -13,95 +12,31 @@ const (
 	dcimEndpointLocation = "dcim/locations/"
 )
 
-type (
-	// Location : Represents a location in Nautobot.
-	Location struct {
-		ID              uuid.UUID      `json:"id"`
-		ASN             *int           `json:"asn"`
-		CircuitCount    int            `json:"circuit_count"`
-		Comments        string         `json:"comments"`
-		ContactEmail    string         `json:"contact_email"`
-		ContactName     string         `json:"contact_name"`
-		ContactPhone    string         `json:"contact_phone"`
-		Created         time.Time      `json:"created"`
-		CustomFields    map[string]any `json:"custom_fields"`
-		Description     string         `json:"description"`
-		DeviceCount     int            `json:"device_count"`
-		Display         string         `json:"display"`
-		Facility        string         `json:"facility"`
-		LastUpdated     time.Time      `json:"last_updated"`
-		Latitude        *float64       `json:"latitude,string"`
-		LocationType    LocationType   `json:"location_type"`
-		Longitude       *float64       `json:"longitude,string"`
-		Name            string         `json:"name"`
-		NaturalSlug     string         `json:"natural_slug"`
-		NotesURL        string         `json:"notes_url"`
-		ObjectType      string         `json:"object_type"`
-		Parent          *Location      `json:"parent"`
-		PhysicalAddress string         `json:"physical_address"`
-		PrefixCount     int            `json:"prefix_count"`
-		RackCount       int            `json:"rack_count"`
-		ShippingAddress string         `json:"shipping_address"`
-		Status          types.Status   `json:"status"`
-		Tags            []types.Tag    `json:"tags"`
-		Tenant          *types.Tenant  `json:"tenant"`
-		TimeZone        *string        `json:"time_zone"`
-		TreeDepth       *int           `json:"tree_depth"`
-		URL             string         `json:"url"`
-		VMCount         int            `json:"virtual_machine_count"`
-		VLANCount       int            `json:"vlan_count"`
-	}
-
-	// NewLocation : Represents a new location to be created in Nautobot.
-	NewLocation struct {
-		Name            string         `json:"name"`
-		LocationType    string         `json:"location_type"`
-		Status          string         `json:"status"`
-		ASN             int            `json:"asn,omitempty"`
-		Comments        string         `json:"comments,omitempty"`
-		ContactEmail    string         `json:"contact_email,omitempty"`
-		ContactName     string         `json:"contact_name,omitempty"`
-		ContactPhone    string         `json:"contact_phone,omitempty"`
-		CustomFields    map[string]any `json:"custom_fields,omitempty"`
-		Description     string         `json:"description,omitempty"`
-		Facility        string         `json:"facility,omitempty"`
-		Latitude        *float64       `json:"latitude,omitempty"`
-		Longitude       *float64       `json:"longitude,omitempty"`
-		Parent          string         `json:"parent,omitempty"`
-		PhysicalAddress string         `json:"physical_address,omitempty"`
-		Relationships   map[string]any `json:"relationships,omitempty"`
-		ShippingAddress string         `json:"shipping_address,omitempty"`
-		Tags            []string       `json:"tags,omitempty"`
-		Tenant          string         `json:"tenant,omitempty"`
-		TimeZone        string         `json:"time_zone,omitempty"`
-	}
-)
-
 // LocationGet : Get a Location by UUID identifier.
-func (c *Client) LocationGet(id uuid.UUID) (*Location, error) {
-	return core.Get[Location](c.Client, dcimEndpointLocation, id)
+func (c *Client) LocationGet(id uuid.UUID) (*types.Location, error) {
+	return core.Get[types.Location](c.Client, dcimEndpointLocation, id)
 }
 
 // LocationFilter : Get a list of Locations based on query parameters.
-func (c *Client) LocationFilter(q *url.Values) ([]Location, error) {
-	locationTypes := make([]Location, 0)
-	return locationTypes, core.Paginate[Location](c.Client, dcimEndpointLocation, q, &locationTypes)
+func (c *Client) LocationFilter(q *url.Values) ([]types.Location, error) {
+	locationTypes := make([]types.Location, 0)
+	return locationTypes, core.Paginate[types.Location](c.Client, dcimEndpointLocation, q, &locationTypes)
 }
 
 // LocationAll : Get all Locations in Nautobot.
-func (c *Client) LocationAll() ([]Location, error) {
-	locationTypes := make([]Location, 0)
-	return locationTypes, core.Paginate[Location](c.Client, dcimEndpointLocation, nil, &locationTypes)
+func (c *Client) LocationAll() ([]types.Location, error) {
+	locationTypes := make([]types.Location, 0)
+	return locationTypes, core.Paginate[types.Location](c.Client, dcimEndpointLocation, nil, &locationTypes)
 }
 
 // LocationCreate : Generate a new Location record in Nautobot.
-func (c *Client) LocationCreate(obj NewLocation) (*Location, error) {
-	return core.Create[Location, NewLocation](c.Client, dcimEndpointLocation, obj)
+func (c *Client) LocationCreate(obj types.NewLocation) (*types.Location, error) {
+	return core.Create[types.Location, types.NewLocation](c.Client, dcimEndpointLocation, obj)
 }
 
 // LocationUpdate : Update an existing Location record in Nautobot.
-func (c *Client) LocationUpdate(id uuid.UUID, patch map[string]any) (*Location, error) {
-	return core.Update[Location](c.Client, dcimEndpointLocation, id, patch)
+func (c *Client) LocationUpdate(id uuid.UUID, patch map[string]any) (*types.Location, error) {
+	return core.Update[types.Location](c.Client, dcimEndpointLocation, id, patch)
 }
 
 // LocationDelete : Delete a Location by UUID identifier.

--- a/dcim/locationtype.go
+++ b/dcim/locationtype.go
@@ -2,72 +2,41 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
+	"github.com/neverbeencloser/gonautobot/types"
 )
 
 const (
 	dcimEndpointLocationType = "dcim/location-types/"
 )
 
-type (
-	// LocationType : Represents a location type in Nautobot.
-	LocationType struct {
-		ID           uuid.UUID      `json:"id"`
-		ContentTypes []string       `json:"content_types"`
-		Created      time.Time      `json:"created"`
-		CustomFields map[string]any `json:"custom_fields"`
-		Description  string         `json:"description"`
-		Display      string         `json:"display"`
-		LastUpdated  time.Time      `json:"last_updated"`
-		Name         string         `json:"name"`
-		NaturalSlug  string         `json:"natural_slug"`
-		Nestable     bool           `json:"nestable"`
-		NotesURL     string         `json:"notes_url"`
-		ObjectType   string         `json:"object_type"`
-		Parent       *LocationType  `json:"parent"`
-		TreeDepth    *int           `json:"tree_depth"`
-		URL          string         `json:"url"`
-	}
-
-	// NewLocationType : Represents a new location type to be created in Nautobot.
-	NewLocationType struct {
-		Name         string         `json:"name"`
-		ContentTypes []string       `json:"content_types"`
-		CustomFields map[string]any `json:"custom_fields,omitempty"`
-		Description  string         `json:"description,omitempty"`
-		Nestable     bool           `json:"nestable,omitempty"`
-		Parent       string         `json:"parent,omitempty"`
-	}
-)
-
 // LocationTypeGet : Get a LocationType by UUID identifier.
-func (c *Client) LocationTypeGet(id uuid.UUID) (*LocationType, error) {
-	return core.Get[LocationType](c.Client, dcimEndpointLocationType, id)
+func (c *Client) LocationTypeGet(id uuid.UUID) (*types.LocationType, error) {
+	return core.Get[types.LocationType](c.Client, dcimEndpointLocationType, id)
 }
 
 // LocationTypeFilter : Get a list of LocationTypes based on query parameters.
-func (c *Client) LocationTypeFilter(q *url.Values) ([]LocationType, error) {
-	locationTypes := make([]LocationType, 0)
-	return locationTypes, core.Paginate[LocationType](c.Client, dcimEndpointLocationType, q, &locationTypes)
+func (c *Client) LocationTypeFilter(q *url.Values) ([]types.LocationType, error) {
+	locationTypes := make([]types.LocationType, 0)
+	return locationTypes, core.Paginate[types.LocationType](c.Client, dcimEndpointLocationType, q, &locationTypes)
 }
 
 // LocationTypeAll : Get all LocationTypes in Nautobot.
-func (c *Client) LocationTypeAll() ([]LocationType, error) {
-	locationTypes := make([]LocationType, 0)
-	return locationTypes, core.Paginate[LocationType](c.Client, dcimEndpointLocationType, nil, &locationTypes)
+func (c *Client) LocationTypeAll() ([]types.LocationType, error) {
+	locationTypes := make([]types.LocationType, 0)
+	return locationTypes, core.Paginate[types.LocationType](c.Client, dcimEndpointLocationType, nil, &locationTypes)
 }
 
 // LocationTypeCreate : Generate a new LocationType record in Nautobot.
-func (c *Client) LocationTypeCreate(obj NewLocationType) (*LocationType, error) {
-	return core.Create[LocationType, NewLocationType](c.Client, dcimEndpointLocationType, obj)
+func (c *Client) LocationTypeCreate(obj types.NewLocationType) (*types.LocationType, error) {
+	return core.Create[types.LocationType, types.NewLocationType](c.Client, dcimEndpointLocationType, obj)
 }
 
 // LocationTypeUpdate : Update an existing LocationType record in Nautobot.
-func (c *Client) LocationTypeUpdate(id uuid.UUID, patch map[string]any) (*LocationType, error) {
-	return core.Update[LocationType](c.Client, dcimEndpointLocationType, id, patch)
+func (c *Client) LocationTypeUpdate(id uuid.UUID, patch map[string]any) (*types.LocationType, error) {
+	return core.Update[types.LocationType](c.Client, dcimEndpointLocationType, id, patch)
 }
 
 // LocationTypeDelete : Delete a LocationType by UUID identifier.

--- a/dcim/manufacturer.go
+++ b/dcim/manufacturer.go
@@ -2,64 +2,36 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
+	"github.com/neverbeencloser/gonautobot/types"
 )
 
 const (
 	dcimEndpointManufacturer = "dcim/manufacturers/"
 )
 
-type (
-	// Manufacturer represents a manufacturer in Nautobot's DCIM application.
-	Manufacturer struct {
-		ID                 uuid.UUID      `json:"id"`
-		CloudAccountCount  int            `json:"cloud_account_count"`
-		Created            time.Time      `json:"created"`
-		CustomFields       map[string]any `json:"custom_fields"`
-		Description        string         `json:"description"`
-		DeviceTypeCount    int            `json:"device_type_count"`
-		Display            string         `json:"display"`
-		InventoryItemCount int            `json:"inventory_item_count"`
-		LastUpdated        time.Time      `json:"last_updated"`
-		Name               string         `json:"name"`
-		NaturalSlug        string         `json:"natural_slug"`
-		NotesURL           string         `json:"notes_url"`
-		ObjectType         string         `json:"object_type"`
-		PlatformCount      int            `json:"platform_count"`
-		URL                string         `json:"url"`
-	}
-
-	// NewManufacturer represents the data required to create a new manufacturer.
-	NewManufacturer struct {
-		Name         string         `json:"name"`
-		CustomFields map[string]any `json:"custom_fields,omitempty"`
-		Description  string         `json:"description,omitempty"`
-	}
-)
-
 // ManufacturerGet : Get a Manufacturer by UUID identifier.
-func (c *Client) ManufacturerGet(id uuid.UUID) (*Manufacturer, error) {
-	return core.Get[Manufacturer](c.Client, dcimEndpointManufacturer, id)
+func (c *Client) ManufacturerGet(id uuid.UUID) (*types.Manufacturer, error) {
+	return core.Get[types.Manufacturer](c.Client, dcimEndpointManufacturer, id)
 }
 
 // ManufacturerFilter : Get a list of Manufacturers based on query parameters.
-func (c *Client) ManufacturerFilter(q *url.Values) ([]Manufacturer, error) {
-	manufacturers := make([]Manufacturer, 0)
-	return manufacturers, core.Paginate[Manufacturer](c.Client, dcimEndpointManufacturer, q, &manufacturers)
+func (c *Client) ManufacturerFilter(q *url.Values) ([]types.Manufacturer, error) {
+	manufacturers := make([]types.Manufacturer, 0)
+	return manufacturers, core.Paginate[types.Manufacturer](c.Client, dcimEndpointManufacturer, q, &manufacturers)
 }
 
 // ManufacturerAll : Get all Manufacturers in Nautobot.
-func (c *Client) ManufacturerAll() ([]Manufacturer, error) {
-	manufacturers := make([]Manufacturer, 0)
-	return manufacturers, core.Paginate[Manufacturer](c.Client, dcimEndpointManufacturer, nil, &manufacturers)
+func (c *Client) ManufacturerAll() ([]types.Manufacturer, error) {
+	manufacturers := make([]types.Manufacturer, 0)
+	return manufacturers, core.Paginate[types.Manufacturer](c.Client, dcimEndpointManufacturer, nil, &manufacturers)
 }
 
 // ManufacturerCreate : Generate a new Manufacturer record in Nautobot.
-func (c *Client) ManufacturerCreate(obj NewManufacturer) (*Manufacturer, error) {
-	return core.Create[Manufacturer, NewManufacturer](c.Client, dcimEndpointManufacturer, obj)
+func (c *Client) ManufacturerCreate(obj types.NewManufacturer) (*types.Manufacturer, error) {
+	return core.Create[types.Manufacturer, types.NewManufacturer](c.Client, dcimEndpointManufacturer, obj)
 }
 
 // ManufacturerDelete : Delete a Manufacturer by UUID identifier.
@@ -68,6 +40,6 @@ func (c *Client) ManufacturerDelete(id uuid.UUID) error {
 }
 
 // ManufacturerUpdate : Update an existing Manufacturer record in Nautobot.
-func (c *Client) ManufacturerUpdate(id uuid.UUID, patch map[string]any) (*Manufacturer, error) {
-	return core.Update[Manufacturer](c.Client, dcimEndpointManufacturer, id, patch)
+func (c *Client) ManufacturerUpdate(id uuid.UUID, patch map[string]any) (*types.Manufacturer, error) {
+	return core.Update[types.Manufacturer](c.Client, dcimEndpointManufacturer, id, patch)
 }

--- a/dcim/platform.go
+++ b/dcim/platform.go
@@ -2,72 +2,36 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
+	"github.com/neverbeencloser/gonautobot/types"
 )
 
 const (
 	dcimEndpointPlatform = "dcim/platforms/"
 )
 
-type (
-	// Platform represents a device platform in Nautobot.
-	Platform struct {
-		ID                    uuid.UUID      `json:"id"`
-		Created               time.Time      `json:"created"`
-		CustomFields          map[string]any `json:"custom_fields"`
-		Description           string         `json:"description"`
-		DeviceCount           int            `json:"device_count"`
-		Display               string         `json:"display"`
-		LastUpdated           time.Time      `json:"last_updated"`
-		Manufacturer          *Manufacturer  `json:"manufacturer"`
-		Name                  string         `json:"name"`
-		NapalmArgs            any            `json:"napalm_args"`
-		NapalmDriver          string         `json:"napalm_driver"`
-		NaturalSlug           string         `json:"natural_slug"`
-		NetworkDriver         string         `json:"network_driver"`
-		NetworkDriverMappings map[string]any `json:"network_driver_mappings"`
-		NotesURL              string         `json:"notes_url"`
-		ObjectType            string         `json:"object_type"`
-		URL                   string         `json:"url"`
-		VMCount               int            `json:"virtual_machine_count"`
-	}
-
-	// NewPlatform represents the data required to create a new platform.
-	NewPlatform struct {
-		Name          string         `json:"name"`
-		CustomFields  map[string]any `json:"custom_fields,omitempty"`
-		Description   string         `json:"description,omitempty"`
-		Manufacturer  string         `json:"manufacturer,omitempty"`
-		NapalmArgs    any            `json:"napalm_args,omitempty"`
-		NapalmDriver  string         `json:"napalm_driver,omitempty"`
-		NetworkDriver string         `json:"network_driver,omitempty"`
-		Relationships map[string]any `json:"relationships,omitempty"`
-	}
-)
-
 // PlatformGet : Get a Platform by UUID identifier.
-func (c *Client) PlatformGet(id uuid.UUID) (*Platform, error) {
-	return core.Get[Platform](c.Client, dcimEndpointPlatform, id)
+func (c *Client) PlatformGet(id uuid.UUID) (*types.Platform, error) {
+	return core.Get[types.Platform](c.Client, dcimEndpointPlatform, id)
 }
 
 // PlatformFilter : Get a list of Platforms based on query parameters.
-func (c *Client) PlatformFilter(q *url.Values) ([]Platform, error) {
-	platforms := make([]Platform, 0)
-	return platforms, core.Paginate[Platform](c.Client, dcimEndpointPlatform, q, &platforms)
+func (c *Client) PlatformFilter(q *url.Values) ([]types.Platform, error) {
+	platforms := make([]types.Platform, 0)
+	return platforms, core.Paginate[types.Platform](c.Client, dcimEndpointPlatform, q, &platforms)
 }
 
 // PlatformAll : Get all Platforms in Nautobot.
-func (c *Client) PlatformAll() ([]Platform, error) {
-	platforms := make([]Platform, 0)
-	return platforms, core.Paginate[Platform](c.Client, dcimEndpointPlatform, nil, &platforms)
+func (c *Client) PlatformAll() ([]types.Platform, error) {
+	platforms := make([]types.Platform, 0)
+	return platforms, core.Paginate[types.Platform](c.Client, dcimEndpointPlatform, nil, &platforms)
 }
 
 // PlatformCreate : Generate a new Platform record in Nautobot.
-func (c *Client) PlatformCreate(obj NewPlatform) (*Platform, error) {
-	return core.Create[Platform, NewPlatform](c.Client, dcimEndpointPlatform, obj)
+func (c *Client) PlatformCreate(obj types.NewPlatform) (*types.Platform, error) {
+	return core.Create[types.Platform, types.NewPlatform](c.Client, dcimEndpointPlatform, obj)
 }
 
 // PlatformDelete : Delete a Platform by UUID identifier.
@@ -76,6 +40,6 @@ func (c *Client) PlatformDelete(id uuid.UUID) error {
 }
 
 // PlatformUpdate : Update an existing Platform record in Nautobot.
-func (c *Client) PlatformUpdate(id uuid.UUID, patch map[string]any) (*Platform, error) {
-	return core.Update[Platform](c.Client, dcimEndpointPlatform, id, patch)
+func (c *Client) PlatformUpdate(id uuid.UUID, patch map[string]any) (*types.Platform, error) {
+	return core.Update[types.Platform](c.Client, dcimEndpointPlatform, id, patch)
 }

--- a/dcim/rack.go
+++ b/dcim/rack.go
@@ -2,7 +2,6 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
@@ -14,85 +13,26 @@ const (
 	dcimEndpointRack = "dcim/racks/"
 )
 
-type (
-	// Rack : Data type entry for a Rack in Nautobot.
-	Rack struct {
-		ID             uuid.UUID           `json:"id"`
-		AssetTag       *string             `json:"asset_tag"`
-		Comments       string              `json:"comments"`
-		Created        time.Time           `json:"created"`
-		CustomFields   map[string]any      `json:"custom_fields"`
-		DescUnits      bool                `json:"desc_units"`
-		DeviceCount    int                 `json:"device_count"`
-		Display        string              `json:"display"`
-		FacilityID     *string             `json:"facility_id"`
-		LastUpdated    time.Time           `json:"last_updated"`
-		Location       Location            `json:"location"`
-		Name           string              `json:"name"`
-		NaturalSlug    string              `json:"natural_slug"`
-		NotesURL       string              `json:"notes_url"`
-		ObjectType     string              `json:"object_type"`
-		OuterDepth     *int                `json:"outer_depth"`
-		OuterUnit      *types.LabelValue   `json:"outer_unit"`
-		OuterWidth     *int                `json:"outer_width"`
-		PowerFeedCount int                 `json:"power_feed_count"`
-		RackGroup      *RackGroup          `json:"rack_group"`
-		Role           *types.Role         `json:"role"`
-		Serial         string              `json:"serial"`
-		Status         types.Status        `json:"status"`
-		Tags           []types.Tag         `json:"tags"`
-		Tenant         *types.Tenant       `json:"tenant"`
-		Type           *types.LabelValue   `json:"type"`
-		UHeight        int                 `json:"u_height"`
-		URL            string              `json:"url"`
-		Width          types.LabelValueInt `json:"width"`
-	}
-
-	// NewRack represents the structure for creating a new Rack in Nautobot.
-	NewRack struct {
-		Location      string         `json:"location"`
-		Name          string         `json:"name"`
-		Status        string         `json:"status"`
-		Width         int            `json:"width"`
-		UHeight       int            `json:"u_height"`
-		AssetTag      string         `json:"asset_tag,omitempty"`
-		Comments      string         `json:"comments,omitempty"`
-		CustomFields  map[string]any `json:"custom_fields,omitempty"`
-		DescUnits     bool           `json:"desc_units,omitempty"`
-		FacilityID    string         `json:"facility_id,omitempty"`
-		OuterDepth    int            `json:"outer_depth,omitempty"`
-		OuterUnit     string         `json:"outer_unit,omitempty"`
-		OuterWidth    int            `json:"outer_width,omitempty"`
-		RackGroup     string         `json:"rack_group,omitempty"`
-		Relationships map[string]any `json:"relationships,omitempty"`
-		Role          string         `json:"role,omitempty"`
-		Serial        string         `json:"serial,omitempty"`
-		Tags          []string       `json:"tags,omitempty"`
-		Tenant        string         `json:"tenant,omitempty"`
-		Type          string         `json:"type,omitempty"`
-	}
-)
-
 // RackGet : Get a Rack by UUID identifier.
-func (c *Client) RackGet(id uuid.UUID) (*Rack, error) {
-	return core.Get[Rack](c.Client, dcimEndpointRack, id)
+func (c *Client) RackGet(id uuid.UUID) (*types.Rack, error) {
+	return core.Get[types.Rack](c.Client, dcimEndpointRack, id)
 }
 
 // RackFilter : Get a list of Racks based on query parameters.
-func (c *Client) RackFilter(q *url.Values) ([]Rack, error) {
-	racks := make([]Rack, 0)
-	return racks, core.Paginate[Rack](c.Client, dcimEndpointRack, q, &racks)
+func (c *Client) RackFilter(q *url.Values) ([]types.Rack, error) {
+	racks := make([]types.Rack, 0)
+	return racks, core.Paginate[types.Rack](c.Client, dcimEndpointRack, q, &racks)
 }
 
 // RackAll : Get all Racks in Nautobot.
-func (c *Client) RackAll() ([]Rack, error) {
-	racks := make([]Rack, 0)
-	return racks, core.Paginate[Rack](c.Client, dcimEndpointRack, nil, &racks)
+func (c *Client) RackAll() ([]types.Rack, error) {
+	racks := make([]types.Rack, 0)
+	return racks, core.Paginate[types.Rack](c.Client, dcimEndpointRack, nil, &racks)
 }
 
 // RackCreate : Generate a new Rack record in Nautobot.
-func (c *Client) RackCreate(obj NewRack) (*Rack, error) {
-	return core.Create[Rack, NewRack](c.Client, dcimEndpointRack, obj)
+func (c *Client) RackCreate(obj types.NewRack) (*types.Rack, error) {
+	return core.Create[types.Rack, types.NewRack](c.Client, dcimEndpointRack, obj)
 }
 
 // RackDelete : Delete a Rack by UUID identifier.
@@ -101,6 +41,6 @@ func (c *Client) RackDelete(id uuid.UUID) error {
 }
 
 // RackUpdate : Update an existing Rack record in Nautobot.
-func (c *Client) RackUpdate(id uuid.UUID, patch map[string]any) (*Rack, error) {
-	return core.Update[Rack](c.Client, dcimEndpointRack, id, patch)
+func (c *Client) RackUpdate(id uuid.UUID, patch map[string]any) (*types.Rack, error) {
+	return core.Update[types.Rack](c.Client, dcimEndpointRack, id, patch)
 }

--- a/dcim/rackgroup.go
+++ b/dcim/rackgroup.go
@@ -2,67 +2,36 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
+	"github.com/neverbeencloser/gonautobot/types"
 )
 
 const (
 	dcimEndpointRackGroup = "dcim/rack-groups/"
 )
 
-type (
-	// RackGroup : Data type entry for a RackGroup in Nautobot.
-	RackGroup struct {
-		ID           uuid.UUID      `json:"id"`
-		Created      time.Time      `json:"created"`
-		CustomFields map[string]any `json:"custom_fields"`
-		Description  string         `json:"description"`
-		Display      string         `json:"display"`
-		LastUpdated  time.Time      `json:"last_updated"`
-		Location     Location       `json:"location"`
-		Name         string         `json:"name"`
-		NaturalSlug  string         `json:"natural_slug"`
-		NotesURL     string         `json:"notes_url"`
-		ObjectType   string         `json:"object_type"`
-		Parent       *RackGroup     `json:"parent"`
-		RackCount    int            `json:"rack_count"`
-		TreeDepth    *int           `json:"tree_depth"`
-		URL          string         `json:"url"`
-	}
-
-	// NewRackGroup represents the structure for creating a new RackGroup in Nautobot.
-	NewRackGroup struct {
-		CustomFields  map[string]any `json:"custom_fields,omitempty"`
-		Description   string         `json:"description,omitempty"`
-		Location      string         `json:"location"`
-		Name          string         `json:"name"`
-		Parent        string         `json:"parent,omitempty"`
-		Relationships map[string]any `json:"relationships,omitempty"`
-	}
-)
-
 // RackGroupGet : Get a RackGroup by UUID identifier.
-func (c *Client) RackGroupGet(id uuid.UUID) (*RackGroup, error) {
-	return core.Get[RackGroup](c.Client, dcimEndpointRackGroup, id)
+func (c *Client) RackGroupGet(id uuid.UUID) (*types.RackGroup, error) {
+	return core.Get[types.RackGroup](c.Client, dcimEndpointRackGroup, id)
 }
 
 // RackGroupFilter : Get a list of RackGroups based on query parameters.
-func (c *Client) RackGroupFilter(q *url.Values) ([]RackGroup, error) {
-	rackGroups := make([]RackGroup, 0)
-	return rackGroups, core.Paginate[RackGroup](c.Client, dcimEndpointRackGroup, q, &rackGroups)
+func (c *Client) RackGroupFilter(q *url.Values) ([]types.RackGroup, error) {
+	rackGroups := make([]types.RackGroup, 0)
+	return rackGroups, core.Paginate[types.RackGroup](c.Client, dcimEndpointRackGroup, q, &rackGroups)
 }
 
 // RackGroupAll : Get all RackGroups in Nautobot.
-func (c *Client) RackGroupAll() ([]RackGroup, error) {
-	rackGroups := make([]RackGroup, 0)
-	return rackGroups, core.Paginate[RackGroup](c.Client, dcimEndpointRackGroup, nil, &rackGroups)
+func (c *Client) RackGroupAll() ([]types.RackGroup, error) {
+	rackGroups := make([]types.RackGroup, 0)
+	return rackGroups, core.Paginate[types.RackGroup](c.Client, dcimEndpointRackGroup, nil, &rackGroups)
 }
 
 // RackGroupCreate : Generate a new RackGroup record in Nautobot.
-func (c *Client) RackGroupCreate(obj NewRackGroup) (*RackGroup, error) {
-	return core.Create[RackGroup, NewRackGroup](c.Client, dcimEndpointRackGroup, obj)
+func (c *Client) RackGroupCreate(obj types.NewRackGroup) (*types.RackGroup, error) {
+	return core.Create[types.RackGroup, types.NewRackGroup](c.Client, dcimEndpointRackGroup, obj)
 }
 
 // RackGroupDelete : Delete a RackGroup by UUID identifier.
@@ -71,6 +40,6 @@ func (c *Client) RackGroupDelete(id uuid.UUID) error {
 }
 
 // RackGroupUpdate : Update an existing RackGroup record in Nautobot.
-func (c *Client) RackGroupUpdate(id uuid.UUID, patch map[string]any) (*RackGroup, error) {
-	return core.Update[RackGroup](c.Client, dcimEndpointRackGroup, id, patch)
+func (c *Client) RackGroupUpdate(id uuid.UUID, patch map[string]any) (*types.RackGroup, error) {
+	return core.Update[types.RackGroup](c.Client, dcimEndpointRackGroup, id, patch)
 }

--- a/dcim/region.go
+++ b/dcim/region.go
@@ -2,40 +2,23 @@ package dcim
 
 import (
 	"fmt"
-	"github.com/neverbeencloser/gonautobot/core"
 	"net/http"
 	"net/url"
-)
 
-type (
-	// Region : defines a region object in Nautobot
-	Region struct {
-		ID           string         `json:"id"`
-		Created      string         `json:"created"`
-		CustomFields map[string]any `json:"custom_fields"`
-		Depth        int            `json:"_depth"`
-		Description  string         `json:"description" datastore:",noindex"`
-		Display      string         `json:"display"`
-		LastUpdated  string         `json:"last_updated"`
-		Name         string         `json:"name"`
-		NotesURL     string         `json:"notes_url"`
-		Parent       *Region        `json:"parent"`
-		SiteCount    int            `json:"site_count"`
-		Slug         string         `json:"slug"`
-		URL          string         `json:"url"`
-	}
+	"github.com/neverbeencloser/gonautobot/core"
+	"github.com/neverbeencloser/gonautobot/types"
 )
 
 // RegionGet : Go function to process requests for the endpoint: /api/dcim/regions/:id/
 //
 // https://demo.nautobot.com/api/docs/#/dcim/dcim_regions_retrieve
-func (c *Client) RegionGet(uuid string) (*Region, error) {
+func (c *Client) RegionGet(uuid string) (*types.Region, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("dcim/regions/%s/", url.PathEscape(uuid)), nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := new(Region)
+	ret := new(types.Region)
 	err = c.UnmarshalDo(req, ret)
 	return ret, err
 }
@@ -43,9 +26,9 @@ func (c *Client) RegionGet(uuid string) (*Region, error) {
 // RegionFilter : Go function to process requests for the endpoint: /api/dcim/regions/
 //
 // https://demo.nautobot.com/api/docs/#/dcim/dcim_regions_list
-func (c *Client) RegionFilter(q *url.Values) ([]Region, error) {
-	resp := make([]Region, 0)
-	if err := core.Paginate[Region](c.Client, "dcim/regions/", q, &resp); err != nil {
+func (c *Client) RegionFilter(q *url.Values) ([]types.Region, error) {
+	resp := make([]types.Region, 0)
+	if err := core.Paginate[types.Region](c.Client, "dcim/regions/", q, &resp); err != nil {
 		return nil, err
 	}
 	return resp, nil

--- a/dcim/site.go
+++ b/dcim/site.go
@@ -7,56 +7,18 @@ import (
 	"net/url"
 
 	"github.com/neverbeencloser/gonautobot/types"
-	"github.com/neverbeencloser/gonautobot/types/nested"
-)
-
-type (
-	// Site : Data representation of a Site model in Nautobot.
-	Site struct {
-		ASN                 *int              `json:"asn"`
-		CircuitCount        int               `json:"circuit_count"`
-		Comments            string            `json:"comments" datastore:",noindex"`
-		ContactEmail        string            `json:"contact_email"`
-		ContactName         string            `json:"contact_name"`
-		ContactPhone        string            `json:"contact_phone"`
-		Created             string            `json:"created"`
-		CustomFields        map[string]any    `json:"custom_fields"`
-		Description         string            `json:"description"`
-		DeviceCount         int               `json:"device_count"`
-		Display             string            `json:"display"`
-		Facility            string            `json:"facility"`
-		ID                  string            `json:"id"`
-		LastUpdated         string            `json:"last_updated"`
-		Latitude            json.RawMessage   `json:"latitude"`
-		Longitude           json.RawMessage   `json:"longitude"`
-		Name                string            `json:"name"`
-		NotesURL            string            `json:"notes_url"`
-		PhysicalAddress     string            `json:"physical_address"`
-		PrefixCount         int               `json:"prefix_count"`
-		RackCount           int               `json:"rack_count"`
-		Region              *Region           `json:"region"`
-		ShippingAddress     string            `json:"shipping_address"`
-		Slug                string            `json:"slug"`
-		Status              *types.LabelValue `json:"status"`
-		Tags                []types.Tag       `json:"tags"`
-		Tenant              *nested.Tenant    `json:"tenant"`
-		TimeZone            json.RawMessage   `json:"time_zone"`
-		URL                 string            `json:"url"`
-		VirtualMachineCount int               `json:"virtualmachine_count"`
-		VLANCount           int               `json:"vlan_count"`
-	}
 )
 
 // SiteGet : Go function to process requests for the endpoint: /api/dcim/sites/:id/
 //
 // https://demo.nautobot.com/api/docs/#/dcim/dcim_sites_retrieve
-func (c *Client) SiteGet(uuid string) (*Site, error) {
+func (c *Client) SiteGet(uuid string) (*types.Site, error) {
 	req, err := c.Request(http.MethodGet, fmt.Sprintf("dcim/sites/%s/", url.PathEscape(uuid)), nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := new(Site)
+	ret := new(types.Site)
 	err = c.UnmarshalDo(req, ret)
 	return ret, err
 }
@@ -64,14 +26,14 @@ func (c *Client) SiteGet(uuid string) (*Site, error) {
 // SiteFilter : Go function to process requests for the endpoint: /api/dcim/sites/
 //
 // https://demo.nautobot.com/api/docs/#/dcim/dcim_sites_list
-func (c *Client) SiteFilter(q *url.Values) ([]Site, error) {
+func (c *Client) SiteFilter(q *url.Values) ([]types.Site, error) {
 	req, err := c.Request(http.MethodGet, "dcim/sites/", nil, q)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := new(types.ResponseList)
-	ret := make([]Site, 0)
+	ret := make([]types.Site, 0)
 
 	if err = c.UnmarshalDo(req, resp); err != nil {
 		return ret, err

--- a/dcim/softwareimage.go
+++ b/dcim/softwareimage.go
@@ -2,7 +2,6 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
@@ -13,67 +12,26 @@ const (
 	dcimEndpointSoftwareImageFile = "dcim/software-image-files/"
 )
 
-type (
-	// SoftwareImageFile represents a software image file in Nautobot.
-	SoftwareImageFile struct {
-		ID                  uuid.UUID       `json:"id"`
-		Created             time.Time       `json:"created"`
-		CustomFields        map[string]any  `json:"custom_fields"`
-		DefaultImage        bool            `json:"default_image"`
-		Display             string          `json:"display"`
-		DownloadURL         string          `json:"download_url"`
-		ExternalIntegration *types.Object   `json:"external_integration"`
-		HashingAlgorithm    string          `json:"hashing_algorithm"`
-		ImageFileChecksum   string          `json:"image_file_checksum"`
-		ImageFileName       string          `json:"image_file_name"`
-		ImageFileSize       *int            `json:"image_file_size"`
-		LastUpdated         time.Time       `json:"last_updated"`
-		NaturalSlug         string          `json:"natural_slug"`
-		NotesURL            string          `json:"notes_url"`
-		ObjectType          string          `json:"object_type"`
-		SoftwareVersion     SoftwareVersion `json:"software_version"`
-		Status              types.Status    `json:"status"`
-		Tags                []types.Tag     `json:"tags"`
-		URL                 string          `json:"url"`
-	}
-
-	// NewSoftwareImageFile represents the data required to create a new software image file.
-	NewSoftwareImageFile struct {
-		ImageFileName       string         `json:"image_file_name"`
-		SoftwareVersion     string         `json:"software_version"`
-		Status              string         `json:"status"`
-		CustomFields        map[string]any `json:"custom_fields,omitempty"`
-		DefaultImage        bool           `json:"default_image"`
-		DownloadURL         string         `json:"download_url,omitempty"`
-		ExternalIntegration string         `json:"external_integration,omitempty"`
-		HashingAlgorithm    string         `json:"hashing_algorithm,omitempty"`
-		ImageFileChecksum   string         `json:"image_file_checksum,omitempty"`
-		ImageFileSize       int            `json:"image_file_size,omitempty"`
-		Relationships       map[string]any `json:"relationships,omitempty"`
-		Tags                []string       `json:"tags,omitempty"`
-	}
-)
-
 // SoftwareImageFileGet : Get a SoftwareImageFile by UUID identifier.
-func (c *Client) SoftwareImageFileGet(id uuid.UUID) (*SoftwareImageFile, error) {
-	return core.Get[SoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, id)
+func (c *Client) SoftwareImageFileGet(id uuid.UUID) (*types.SoftwareImageFile, error) {
+	return core.Get[types.SoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, id)
 }
 
 // SoftwareImageFileFilter : Get a list of SoftwareImageFiles based on query parameters.
-func (c *Client) SoftwareImageFileFilter(q *url.Values) ([]SoftwareImageFile, error) {
-	sifs := make([]SoftwareImageFile, 0)
-	return sifs, core.Paginate[SoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, q, &sifs)
+func (c *Client) SoftwareImageFileFilter(q *url.Values) ([]types.SoftwareImageFile, error) {
+	sifs := make([]types.SoftwareImageFile, 0)
+	return sifs, core.Paginate[types.SoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, q, &sifs)
 }
 
 // SoftwareImageFileAll : Get all SoftwareImageFiles in Nautobot.
-func (c *Client) SoftwareImageFileAll() ([]SoftwareImageFile, error) {
-	sifs := make([]SoftwareImageFile, 0)
-	return sifs, core.Paginate[SoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, nil, &sifs)
+func (c *Client) SoftwareImageFileAll() ([]types.SoftwareImageFile, error) {
+	sifs := make([]types.SoftwareImageFile, 0)
+	return sifs, core.Paginate[types.SoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, nil, &sifs)
 }
 
 // SoftwareImageFileCreate : Generate a new SoftwareImageFile record in Nautobot.
-func (c *Client) SoftwareImageFileCreate(obj NewSoftwareImageFile) (*SoftwareImageFile, error) {
-	return core.Create[SoftwareImageFile, NewSoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, obj)
+func (c *Client) SoftwareImageFileCreate(obj types.NewSoftwareImageFile) (*types.SoftwareImageFile, error) {
+	return core.Create[types.SoftwareImageFile, types.NewSoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, obj)
 }
 
 // SoftwareImageFileDelete : Delete a SoftwareImageFile by UUID identifier.
@@ -82,6 +40,6 @@ func (c *Client) SoftwareImageFileDelete(id uuid.UUID) error {
 }
 
 // SoftwareImageFileUpdate : Update an existing SoftwareImageFile record in Nautobot.
-func (c *Client) SoftwareImageFileUpdate(id uuid.UUID, patch map[string]any) (*SoftwareImageFile, error) {
-	return core.Update[SoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, id, patch)
+func (c *Client) SoftwareImageFileUpdate(id uuid.UUID, patch map[string]any) (*types.SoftwareImageFile, error) {
+	return core.Update[types.SoftwareImageFile](c.Client, dcimEndpointSoftwareImageFile, id, patch)
 }

--- a/dcim/softwareversion.go
+++ b/dcim/softwareversion.go
@@ -2,7 +2,6 @@ package dcim
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
@@ -13,66 +12,26 @@ const (
 	dcimEndpointSoftwareVersion = "dcim/software-versions/"
 )
 
-type (
-	// SoftwareVersion represents a software version in Nautobot.
-	SoftwareVersion struct {
-		ID               uuid.UUID      `json:"id"`
-		Alias            string         `json:"alias"`
-		Created          time.Time      `json:"created"`
-		CustomFields     map[string]any `json:"custom_fields"`
-		Display          string         `json:"display"`
-		DocumentationURL string         `json:"documentation_url"`
-		EndOfSupportDate *string        `json:"end_of_support_date"`
-		LastUpdated      time.Time      `json:"last_updated"`
-		LongTermSupport  bool           `json:"long_term_support"`
-		NaturalSlug      string         `json:"natural_slug"`
-		NotesURL         string         `json:"notes_url"`
-		ObjectType       string         `json:"object_type"`
-		Platform         Platform       `json:"platform"`
-		PreRelease       bool           `json:"pre_release"`
-		ReleaseDate      *string        `json:"release_date"`
-		Status           types.Status   `json:"status"`
-		Tags             []types.Tag    `json:"tags"`
-		URL              string         `json:"url"`
-		Version          string         `json:"version"`
-	}
-
-	// NewSoftwareVersion represents the data required to create a new software version.
-	NewSoftwareVersion struct {
-		Platform         string         `json:"platform"`
-		Status           string         `json:"status"`
-		Version          string         `json:"version"`
-		Alias            string         `json:"alias,omitempty"`
-		CustomFields     map[string]any `json:"custom_fields,omitempty"`
-		DocumentationURL string         `json:"documentation_url,omitempty"`
-		EndOfSupportDate string         `json:"end_of_support_date,omitempty"`
-		LongTermSupport  bool           `json:"long_term_support"`
-		PreRelease       bool           `json:"pre_release"`
-		ReleaseDate      string         `json:"release_date,omitempty"`
-		Tags             []string       `json:"tags,omitempty"`
-	}
-)
-
 // SoftwareVersionGet : Get a SoftwareVersion by UUID identifier.
-func (c *Client) SoftwareVersionGet(id uuid.UUID) (*SoftwareVersion, error) {
-	return core.Get[SoftwareVersion](c.Client, dcimEndpointSoftwareVersion, id)
+func (c *Client) SoftwareVersionGet(id uuid.UUID) (*types.SoftwareVersion, error) {
+	return core.Get[types.SoftwareVersion](c.Client, dcimEndpointSoftwareVersion, id)
 }
 
 // SoftwareVersionFilter : Get a list of SoftwareVersions based on query parameters.
-func (c *Client) SoftwareVersionFilter(q *url.Values) ([]SoftwareVersion, error) {
-	softwareVersions := make([]SoftwareVersion, 0)
-	return softwareVersions, core.Paginate[SoftwareVersion](c.Client, dcimEndpointSoftwareVersion, q, &softwareVersions)
+func (c *Client) SoftwareVersionFilter(q *url.Values) ([]types.SoftwareVersion, error) {
+	softwareVersions := make([]types.SoftwareVersion, 0)
+	return softwareVersions, core.Paginate[types.SoftwareVersion](c.Client, dcimEndpointSoftwareVersion, q, &softwareVersions)
 }
 
 // SoftwareVersionAll : Get all SoftwareVersions in Nautobot.
-func (c *Client) SoftwareVersionAll() ([]SoftwareVersion, error) {
-	softwareVersions := make([]SoftwareVersion, 0)
-	return softwareVersions, core.Paginate[SoftwareVersion](c.Client, dcimEndpointSoftwareVersion, nil, &softwareVersions)
+func (c *Client) SoftwareVersionAll() ([]types.SoftwareVersion, error) {
+	softwareVersions := make([]types.SoftwareVersion, 0)
+	return softwareVersions, core.Paginate[types.SoftwareVersion](c.Client, dcimEndpointSoftwareVersion, nil, &softwareVersions)
 }
 
 // SoftwareVersionCreate : Generate a new SoftwareVersion record in Nautobot.
-func (c *Client) SoftwareVersionCreate(obj NewSoftwareVersion) (*SoftwareVersion, error) {
-	return core.Create[SoftwareVersion, NewSoftwareVersion](c.Client, dcimEndpointSoftwareVersion, obj)
+func (c *Client) SoftwareVersionCreate(obj types.NewSoftwareVersion) (*types.SoftwareVersion, error) {
+	return core.Create[types.SoftwareVersion, types.NewSoftwareVersion](c.Client, dcimEndpointSoftwareVersion, obj)
 }
 
 // SoftwareVersionDelete : Delete a SoftwareVersion by UUID identifier.
@@ -81,6 +40,6 @@ func (c *Client) SoftwareVersionDelete(id uuid.UUID) error {
 }
 
 // SoftwareVersionUpdate : Update an existing SoftwareVersion record in Nautobot.
-func (c *Client) SoftwareVersionUpdate(id uuid.UUID, patch map[string]any) (*SoftwareVersion, error) {
-	return core.Update[SoftwareVersion](c.Client, dcimEndpointSoftwareVersion, id, patch)
+func (c *Client) SoftwareVersionUpdate(id uuid.UUID, patch map[string]any) (*types.SoftwareVersion, error) {
+	return core.Update[types.SoftwareVersion](c.Client, dcimEndpointSoftwareVersion, id, patch)
 }

--- a/examples/dcim.go
+++ b/examples/dcim.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/neverbeencloser/gonautobot/dcim"
-	"github.com/rs/zerolog/log"
 	"net/url"
+
+	"github.com/neverbeencloser/gonautobot/types"
+	"github.com/rs/zerolog/log"
 )
 
 // DeviceExample : Example usage of the Device Nautobot methods.
 func (c *ex) DeviceExample() {
-	req := dcim.NewDevice{
+	req := types.NewDevice{
 		Name:       "tst01-device-01",
 		Role:       "edge",
 		Status:     "Active",

--- a/tests/dcim_devicefamily_test.go
+++ b/tests/dcim_devicefamily_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -61,7 +61,7 @@ func TestClient_DeviceFamilyAll(t *testing.T) {
 
 func TestClient_DeviceFamilyCreate(t *testing.T) {
 	defer gock.Off()
-	newDeviceFamily := dcim.NewDeviceFamily{
+	newDeviceFamily := types.NewDeviceFamily{
 		Name:        "Family1",
 		Description: "A family for devices",
 	}

--- a/tests/dcim_devicetype_test.go
+++ b/tests/dcim_devicetype_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
 	"github.com/neverbeencloser/gonautobot/shared"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -60,7 +60,7 @@ func TestClient_DeviceTypeAll(t *testing.T) {
 }
 
 func TestClient_DeviceTypeCreate(t *testing.T) {
-	newDeviceType := dcim.NewDeviceType{
+	newDeviceType := types.NewDeviceType{
 		Model:        "t2.micro",
 		Manufacturer: "acc4c522-cf77-46bf-bdf3-d0e4a69b4d1e",
 		UHeight:      1,
@@ -78,7 +78,7 @@ func TestClient_DeviceTypeCreate(t *testing.T) {
 }
 
 func TestClient_DeviceTypeUpdate(t *testing.T) {
-	updateData := dcim.NewDeviceType{
+	updateData := types.NewDeviceType{
 		Comments: "updated comments",
 	}
 
@@ -117,7 +117,7 @@ func TestCreateMultipartBody(t *testing.T) {
 	err = tmpFile.Close()
 	require.NoError(t, err)
 
-	newDeviceType := dcim.NewDeviceType{
+	newDeviceType := types.NewDeviceType{
 		Model:        "test-model",
 		Manufacturer: "test-manufacturer",
 		UHeight:      1,

--- a/tests/dcim_interface_test.go
+++ b/tests/dcim_interface_test.go
@@ -1,11 +1,12 @@
 package nautobot_test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/url"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gopkg.in/h2non/gock.v1"
 )

--- a/tests/dcim_location_test.go
+++ b/tests/dcim_location_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -67,7 +67,7 @@ func TestClient_LocationAll(t *testing.T) {
 func TestClient_LocationCreate(t *testing.T) {
 	defer gock.Off()
 
-	newLocation := dcim.NewLocation{
+	newLocation := types.NewLocation{
 		Name:         "us-west-1",
 		LocationType: "1d464670-8fd2-4d1e-bd9d-8811bf2d1fe0",
 		Status:       "7e222b0f-efe9-4bb3-81a0-fb9e81db4ca6",

--- a/tests/dcim_locationtype_test.go
+++ b/tests/dcim_locationtype_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -67,7 +67,7 @@ func TestClient_LocationTypeCreate(t *testing.T) {
 	defer gock.Off()
 
 	parentID := testParentLocationTypeID
-	newLocationType := dcim.NewLocationType{
+	newLocationType := types.NewLocationType{
 		Name:         "Site",
 		ContentTypes: []string{"dcim.device", "ipam.prefix", "ipam.vlan", "ipam.vlangroup"},
 		Nestable:     true,

--- a/tests/dcim_manufacturer_test.go
+++ b/tests/dcim_manufacturer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -59,7 +59,7 @@ func TestClient_ManufacturerAll(t *testing.T) {
 
 func TestClient_ManufacturerCreate(t *testing.T) {
 	defer gock.Off()
-	newManufacturer := dcim.NewManufacturer{
+	newManufacturer := types.NewManufacturer{
 		Name:        "AWS",
 		Description: "Amazon Web Services",
 	}

--- a/tests/dcim_platform_test.go
+++ b/tests/dcim_platform_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -58,7 +58,7 @@ func TestClient_PlatformAll(t *testing.T) {
 
 func TestClient_PlatformCreate(t *testing.T) {
 	defer gock.Off()
-	newPlatform := dcim.NewPlatform{
+	newPlatform := types.NewPlatform{
 		Name:         "eos",
 		Manufacturer: "b832f225-56af-4ff3-8e9a-66ab401c84de", // Manufacturer ID from fixture
 	}

--- a/tests/dcim_rack_test.go
+++ b/tests/dcim_rack_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -54,7 +54,7 @@ func TestClient_RackAll(t *testing.T) {
 }
 
 func TestClient_RackCreate(t *testing.T) {
-	newRack := dcim.NewRack{
+	newRack := types.NewRack{
 		Location: "96af6f0f-c573-48d7-8ee1-f4e10545c14c",
 		Name:     "A12-24",
 		Status:   "7069f6d4-e69e-4b7b-a5d1-ac1d4fc59353",

--- a/tests/dcim_rackgroup_test.go
+++ b/tests/dcim_rackgroup_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -54,7 +54,7 @@ func TestClient_RackGroupAll(t *testing.T) {
 }
 
 func TestClient_RackGroupCreate(t *testing.T) {
-	newRackGroup := dcim.NewRackGroup{
+	newRackGroup := types.NewRackGroup{
 		Name:     "rackgroup1",
 		Location: "b840f97e-e6e9-4b8b-b7ce-0e30f3424201",
 	}

--- a/tests/dcim_software_version_test.go
+++ b/tests/dcim_software_version_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -54,7 +54,7 @@ func TestClient_SoftwareVersionAll(t *testing.T) {
 }
 
 func TestClient_SoftwareVersionCreate(t *testing.T) {
-	newSoftwareVersion := dcim.NewSoftwareVersion{
+	newSoftwareVersion := types.NewSoftwareVersion{
 		Platform: "9a47828b-0f74-42b0-8d30-99fd9806cb1f",
 		Status:   "active",
 		Version:  "6.15.2",

--- a/tests/dcim_softwareimage_test.go
+++ b/tests/dcim_softwareimage_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/dcim"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
@@ -54,7 +54,7 @@ func TestClient_SoftwareImageFileAll(t *testing.T) {
 }
 
 func TestClient_SoftwareImageFileCreate(t *testing.T) {
-	newSIF := dcim.NewSoftwareImageFile{
+	newSIF := types.NewSoftwareImageFile{
 		ImageFileName:   "efwwefwf",
 		SoftwareVersion: "bd0d3850-385d-47c5-8117-75de4c92d6c6",
 		Status:          "active",

--- a/types/dcim_console.go
+++ b/types/dcim_console.go
@@ -1,0 +1,42 @@
+package types
+
+type (
+	// ConsolePort : Data representation of a Console Port in Nautobot.
+	ConsolePort struct {
+		ID           string                 `json:"id"`
+		URL          string                 `json:"url"`
+		CustomFields map[string]interface{} `json:"custom_fields"`
+		Device       struct {
+			ID          string `json:"id"`
+			URL         string `json:"url"`
+			Name        string `json:"name"`
+			DisplayName string `json:"display_name"`
+		} `json:"device"`
+		Name                  string            `json:"name"`
+		Label                 string            `json:"label"`
+		Description           string            `json:"description"`
+		ConnectedEndpointType string            `json:"connected_endpoint_type"`
+		ConnectedEndpoint     ConnectedEndpoint `json:"connected_endpoint"`
+		Cable                 struct {
+			ID    string `json:"id"`
+			URL   string `json:"url"`
+			Label string `json:"label"`
+		} `json:"cable"`
+		Tags []Tag `json:"tags"`
+	}
+
+	// ConnectedEndpoint : Struct representing the far-side of the console connection.
+	ConnectedEndpoint struct {
+		ID     string `json:"id"`
+		URL    string `json:"url"`
+		Device struct {
+			ID          string `json:"id"`
+			URL         string `json:"url"`
+			Name        string `json:"name"`
+			DisplayName string `json:"display_name"`
+		} `json:"device"`
+		Name  string `json:"name"`
+		Cable string `json:"cable"`
+		Port  int
+	}
+)

--- a/types/dcim_device.go
+++ b/types/dcim_device.go
@@ -1,0 +1,75 @@
+package types
+
+import "github.com/neverbeencloser/gonautobot/types/nested"
+
+type (
+	// Device : Data structure to represent a device record in Nautobot.
+	Device struct {
+		ID                 string                        `json:"id"`
+		AssetTag           string                        `json:"asset_tag"`
+		Cluster            *nested.VirtualizationCluster `json:"cluster"`
+		Comments           string                        `json:"comments" datastore:",noindex"`
+		ConfigContext      map[string]interface{}        `json:"config_context"`
+		Created            string                        `json:"created"`
+		CustomFields       map[string]interface{}        `json:"custom_fields"`
+		DeviceRole         *nested.DeviceRole            `json:"device_role"`
+		DeviceType         *nested.DeviceType            `json:"device_type"`
+		Display            string                        `json:"display"`
+		Face               *LabelValue                   `json:"face"`
+		LastUpdated        string                        `json:"last_updated"`
+		LocalContextSchema *nested.ConfigContextSchema   `json:"local_context_schema"`
+		LocalContextData   map[string]interface{}        `json:"local_context_data"`
+		Location           *nested.Location              `json:"location"`
+		Name               string                        `json:"name"`
+		NotesURL           string                        `json:"notes_url"`
+		ParentDevice       *Device                       `json:"parent_device"`
+		Platform           *nested.Platform              `json:"platform"`
+		Position           *int                          `json:"position"`
+		PrimaryIP          *nested.IPAddress             `json:"primary_ip"`
+		PrimaryIP4         *nested.IPAddress             `json:"primary_ip4"`
+		PrimaryIP6         *nested.IPAddress             `json:"primary_ip6"`
+		Rack               *nested.Rack                  `json:"rack"`
+		SecretsGroup       *nested.SecretsGroup          `json:"secrets_group"`
+		Serial             string                        `json:"serial"`
+		Site               *Site                         `json:"site"`
+		Status             *LabelValue                   `json:"status"`
+		Tags               []Tag                         `json:"tags"`
+		Tenant             *nested.Tenant                `json:"tenant"`
+		URL                string                        `json:"url"`
+		VCPosition         *int                          `json:"vc_position"`
+		VCPriority         *int                          `json:"vc_priority"`
+		VirtualChassis     *nested.VirtualChassis        `json:"virtual_chassis"`
+	}
+
+	// NewDevice : Structured input for a new Device record in Nautobot.
+	NewDevice struct {
+		Name                         string         `json:"name"`
+		Role                         string         `json:"role"`
+		Status                       string         `json:"status"`
+		DeviceType                   string         `json:"device_type"`
+		Location                     string         `json:"location,omitempty"`
+		Site                         string         `json:"site,omitempty"`
+		Tenant                       string         `json:"tenant,omitempty"`
+		Platform                     string         `json:"platform,omitempty"`
+		Serial                       string         `json:"serial,omitempty"`
+		AssetTag                     string         `json:"asset_tag,omitempty"`
+		Position                     int            `json:"position,omitempty"`
+		Face                         string         `json:"face,omitempty"`
+		VcPosition                   int            `json:"vc_position,omitempty"`
+		VcPriority                   int            `json:"vc_priority,omitempty"`
+		Comments                     string         `json:"comments,omitempty"`
+		Rack                         string         `json:"rack,omitempty"`
+		PrimaryIP4                   string         `json:"primary_ip4,omitempty"`
+		PrimaryIP6                   string         `json:"primary_ip6,omitempty"`
+		Cluster                      string         `json:"cluster,omitempty"`
+		VirtualChassis               string         `json:"virtual_chassis,omitempty"`
+		DeviceRedundancyGroup        string         `json:"device_redundancy_group,omitempty"`
+		SoftwareVersion              string         `json:"software_version,omitempty"`
+		SecretsGroup                 string         `json:"secrets_group,omitempty"`
+		ControllerManagedDeviceGroup string         `json:"controller_managed_device_group,omitempty"`
+		SoftwareImageFiles           []string       `json:"software_image_files,omitempty"`
+		CustomFields                 map[string]any `json:"custom_fields,omitempty"`
+		Tags                         []string       `json:"tags,omitempty"`
+		ParentBay                    string         `json:"parent_bay,omitempty"`
+	}
+)

--- a/types/dcim_devicefamily.go
+++ b/types/dcim_devicefamily.go
@@ -7,15 +7,14 @@ import (
 )
 
 type (
-	// Namespace : Represents a namespace in Nautobot.
-	Namespace struct {
+	// DeviceFamily represents a device family in Nautobot's DCIM module.
+	DeviceFamily struct {
 		ID           uuid.UUID      `json:"id"`
 		Created      time.Time      `json:"created"`
 		CustomFields map[string]any `json:"custom_fields"`
 		Description  string         `json:"description"`
 		Display      string         `json:"display"`
 		LastUpdated  time.Time      `json:"last_updated"`
-		Location     *Location      `json:"location"`
 		Name         string         `json:"name"`
 		NaturalSlug  string         `json:"natural_slug"`
 		NotesURL     string         `json:"notes_url"`
@@ -24,13 +23,11 @@ type (
 		URL          string         `json:"url"`
 	}
 
-	// NewNamespace : Represents a new namespace to be created in Nautobot.
-	NewNamespace struct {
-		Name          string         `json:"name"`
-		CustomFields  map[string]any `json:"custom_fields,omitempty"`
-		Description   string         `json:"description,omitempty"`
-		Location      string         `json:"location,omitempty"`
-		Relationships map[string]any `json:"relationships,omitempty"`
-		Tags          []string       `json:"tags,omitempty"`
+	// NewDeviceFamily represents the data required to create a new device family.
+	NewDeviceFamily struct {
+		Name         string         `json:"name"`
+		CustomFields map[string]any `json:"custom_fields,omitempty"`
+		Description  string         `json:"description,omitempty"`
+		Tags         []string       `json:"tags,omitempty"`
 	}
 )

--- a/types/dcim_devicetype.go
+++ b/types/dcim_devicetype.go
@@ -1,0 +1,64 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type (
+	// DeviceType represents a device type in Nautobot.
+	DeviceType struct {
+		ID                 uuid.UUID           `json:"id"`
+		Comments           string              `json:"comments"`
+		Created            time.Time           `json:"created"`
+		CustomFields       map[string]any      `json:"custom_fields"`
+		DeviceCount        int                 `json:"device_count"`
+		DeviceFamily       *DeviceFamily       `json:"device_family"`
+		Display            string              `json:"display"`
+		FrontImage         *string             `json:"front_image"`
+		IsFullDepth        bool                `json:"is_full_depth"`
+		LastUpdated        time.Time           `json:"last_updated"`
+		Manufacturer       *Manufacturer       `json:"manufacturer"`
+		Model              string              `json:"model"`
+		NaturalSlug        string              `json:"natural_slug"`
+		NotesURL           string              `json:"notes_url"`
+		ObjectType         string              `json:"object_type"`
+		PartNumber         string              `json:"part_number"`
+		RearImage          *string             `json:"rear_image"`
+		SoftwareImageFiles []SoftwareImageFile `json:"software_image_files"`
+		SubDeviceRole      *LabelValue         `json:"subdevice_role"`
+		Tags               []Tag               `json:"tags"`
+		UHeight            int                 `json:"u_height"`
+		URL                string              `json:"url"`
+	}
+
+	// NewDeviceType represents the structure for creating a new DeviceType in Nautobot.
+	//
+	// It uses our internal 'form' tags for generating multipart/form-data requests.
+	NewDeviceType struct {
+		Manufacturer       string         `form:"manufacturer"`
+		Model              string         `form:"model"`
+		Comments           string         `form:"comments"`
+		CustomFields       map[string]any `form:"custom_fields,omitempty"`
+		DeviceFamily       string         `form:"device_family"`
+		FrontImage         *string        `form:"front_image,omitempty,upload"`
+		IsFullDepth        bool           `form:"is_full_depth"`
+		PartNumber         string         `form:"part_number"`
+		RearImage          *string        `form:"rear_image,omitempty,upload"`
+		SoftwareImageFiles []string       `form:"software_image_files,omitempty"`
+		SubDeviceRole      string         `form:"subdevice_role"`
+		Tags               []string       `form:"tags,omitempty"`
+		UHeight            int            `form:"u_height"`
+	}
+)
+
+// SetFrontImage is a convenience method to set the front image path for a NewDeviceType.
+func (n *NewDeviceType) SetFrontImage(path string) {
+	n.FrontImage = &path
+}
+
+// SetRearImage is a convenience method to set the rear image path for a NewDeviceType.
+func (n *NewDeviceType) SetRearImage(path string) {
+	n.RearImage = &path
+}

--- a/types/dcim_interface.go
+++ b/types/dcim_interface.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"encoding/json"
+
+	"github.com/neverbeencloser/gonautobot/types/nested"
+)
+
+type (
+	// DeviceInterface : defines an interface as represented in Nautobot
+	//
+	// CablePeer and ConnectedEndpoint must be decoded dynamically; they are dependent
+	// on the value of 'CablePeerType' and 'ConnectedEndpointType', e.g., "dcim.interface"
+	DeviceInterface struct {
+		ID                         string                 `json:"id"`
+		Bridge                     *DeviceInterface       `json:"bridge"`
+		Cable                      *nested.Cable          `json:"cable"`
+		CablePeer                  json.RawMessage        `json:"cable_peer"`
+		CablePeerType              *string                `json:"cable_peer_type"`
+		ConnectedEndpoint          json.RawMessage        `json:"connected_endpoint"`
+		ConnectedEndpointReachable bool                   `json:"connected_endpoint_reachable"`
+		ConnectedEndpointType      *string                `json:"connected_endpoint_type"`
+		CountIPAddresses           int                    `json:"count_ipaddresses"`
+		Created                    string                 `json:"created"`
+		CustomFields               map[string]interface{} `json:"custom_fields"`
+		Description                string                 `json:"description"`
+		Device                     *Device                `json:"device"`
+		Display                    string                 `json:"display"`
+		Enabled                    bool                   `json:"enabled"`
+		Label                      string                 `json:"label"`
+		Lag                        *DeviceInterface       `json:"lag"`
+		LastUpdated                string                 `json:"last_updated"`
+		MACAddress                 *string                `json:"mac_address"`
+		MgmtOnly                   bool                   `json:"mgmt_only"`
+		Mode                       *LabelValue            `json:"mode"`
+		MTU                        *int                   `json:"mtu"`
+		Name                       string                 `json:"name"`
+		NotesURL                   string                 `json:"notes_url"`
+		ParentInterface            *DeviceInterface       `json:"parent_interface"`
+		TaggedVLANs                []nested.VLAN          `json:"tagged_vlans"`
+		Tags                       []Tag                  `json:"tags"`
+		Type                       *LabelValue            `json:"type"`
+		UntaggedVLAN               *nested.VLAN           `json:"untagged_vlan"`
+		URL                        string                 `json:"url"`
+	}
+)

--- a/types/dcim_location.go
+++ b/types/dcim_location.go
@@ -1,0 +1,71 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type (
+	// Location : Represents a location in Nautobot.
+	Location struct {
+		ID              uuid.UUID      `json:"id"`
+		ASN             *int           `json:"asn"`
+		CircuitCount    int            `json:"circuit_count"`
+		Comments        string         `json:"comments"`
+		ContactEmail    string         `json:"contact_email"`
+		ContactName     string         `json:"contact_name"`
+		ContactPhone    string         `json:"contact_phone"`
+		Created         time.Time      `json:"created"`
+		CustomFields    map[string]any `json:"custom_fields"`
+		Description     string         `json:"description"`
+		DeviceCount     int            `json:"device_count"`
+		Display         string         `json:"display"`
+		Facility        string         `json:"facility"`
+		LastUpdated     time.Time      `json:"last_updated"`
+		Latitude        *float64       `json:"latitude,string"`
+		LocationType    LocationType   `json:"location_type"`
+		Longitude       *float64       `json:"longitude,string"`
+		Name            string         `json:"name"`
+		NaturalSlug     string         `json:"natural_slug"`
+		NotesURL        string         `json:"notes_url"`
+		ObjectType      string         `json:"object_type"`
+		Parent          *Location      `json:"parent"`
+		PhysicalAddress string         `json:"physical_address"`
+		PrefixCount     int            `json:"prefix_count"`
+		RackCount       int            `json:"rack_count"`
+		ShippingAddress string         `json:"shipping_address"`
+		Status          Status         `json:"status"`
+		Tags            []Tag          `json:"tags"`
+		Tenant          *Tenant        `json:"tenant"`
+		TimeZone        *string        `json:"time_zone"`
+		TreeDepth       *int           `json:"tree_depth"`
+		URL             string         `json:"url"`
+		VMCount         int            `json:"virtual_machine_count"`
+		VLANCount       int            `json:"vlan_count"`
+	}
+
+	// NewLocation : Represents a new location to be created in Nautobot.
+	NewLocation struct {
+		Name            string         `json:"name"`
+		LocationType    string         `json:"location_type"`
+		Status          string         `json:"status"`
+		ASN             int            `json:"asn,omitempty"`
+		Comments        string         `json:"comments,omitempty"`
+		ContactEmail    string         `json:"contact_email,omitempty"`
+		ContactName     string         `json:"contact_name,omitempty"`
+		ContactPhone    string         `json:"contact_phone,omitempty"`
+		CustomFields    map[string]any `json:"custom_fields,omitempty"`
+		Description     string         `json:"description,omitempty"`
+		Facility        string         `json:"facility,omitempty"`
+		Latitude        *float64       `json:"latitude,omitempty"`
+		Longitude       *float64       `json:"longitude,omitempty"`
+		Parent          string         `json:"parent,omitempty"`
+		PhysicalAddress string         `json:"physical_address,omitempty"`
+		Relationships   map[string]any `json:"relationships,omitempty"`
+		ShippingAddress string         `json:"shipping_address,omitempty"`
+		Tags            []string       `json:"tags,omitempty"`
+		Tenant          string         `json:"tenant,omitempty"`
+		TimeZone        string         `json:"time_zone,omitempty"`
+	}
+)

--- a/types/dcim_locationtype.go
+++ b/types/dcim_locationtype.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type (
+	// LocationType : Represents a location type in Nautobot.
+	LocationType struct {
+		ID           uuid.UUID      `json:"id"`
+		ContentTypes []string       `json:"content_types"`
+		Created      time.Time      `json:"created"`
+		CustomFields map[string]any `json:"custom_fields"`
+		Description  string         `json:"description"`
+		Display      string         `json:"display"`
+		LastUpdated  time.Time      `json:"last_updated"`
+		Name         string         `json:"name"`
+		NaturalSlug  string         `json:"natural_slug"`
+		Nestable     bool           `json:"nestable"`
+		NotesURL     string         `json:"notes_url"`
+		ObjectType   string         `json:"object_type"`
+		Parent       *LocationType  `json:"parent"`
+		TreeDepth    *int           `json:"tree_depth"`
+		URL          string         `json:"url"`
+	}
+
+	// NewLocationType : Represents a new location type to be created in Nautobot.
+	NewLocationType struct {
+		Name         string         `json:"name"`
+		ContentTypes []string       `json:"content_types"`
+		CustomFields map[string]any `json:"custom_fields,omitempty"`
+		Description  string         `json:"description,omitempty"`
+		Nestable     bool           `json:"nestable,omitempty"`
+		Parent       string         `json:"parent,omitempty"`
+	}
+)

--- a/types/dcim_manufacturer.go
+++ b/types/dcim_manufacturer.go
@@ -1,0 +1,35 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type (
+	// Manufacturer represents a manufacturer in Nautobot's DCIM application.
+	Manufacturer struct {
+		ID                 uuid.UUID      `json:"id"`
+		CloudAccountCount  int            `json:"cloud_account_count"`
+		Created            time.Time      `json:"created"`
+		CustomFields       map[string]any `json:"custom_fields"`
+		Description        string         `json:"description"`
+		DeviceTypeCount    int            `json:"device_type_count"`
+		Display            string         `json:"display"`
+		InventoryItemCount int            `json:"inventory_item_count"`
+		LastUpdated        time.Time      `json:"last_updated"`
+		Name               string         `json:"name"`
+		NaturalSlug        string         `json:"natural_slug"`
+		NotesURL           string         `json:"notes_url"`
+		ObjectType         string         `json:"object_type"`
+		PlatformCount      int            `json:"platform_count"`
+		URL                string         `json:"url"`
+	}
+
+	// NewManufacturer represents the data required to create a new manufacturer.
+	NewManufacturer struct {
+		Name         string         `json:"name"`
+		CustomFields map[string]any `json:"custom_fields,omitempty"`
+		Description  string         `json:"description,omitempty"`
+	}
+)

--- a/types/dcim_platform.go
+++ b/types/dcim_platform.go
@@ -1,0 +1,43 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type (
+	// Platform represents a device platform in Nautobot.
+	Platform struct {
+		ID                    uuid.UUID      `json:"id"`
+		Created               time.Time      `json:"created"`
+		CustomFields          map[string]any `json:"custom_fields"`
+		Description           string         `json:"description"`
+		DeviceCount           int            `json:"device_count"`
+		Display               string         `json:"display"`
+		LastUpdated           time.Time      `json:"last_updated"`
+		Manufacturer          *Manufacturer  `json:"manufacturer"`
+		Name                  string         `json:"name"`
+		NapalmArgs            any            `json:"napalm_args"`
+		NapalmDriver          string         `json:"napalm_driver"`
+		NaturalSlug           string         `json:"natural_slug"`
+		NetworkDriver         string         `json:"network_driver"`
+		NetworkDriverMappings map[string]any `json:"network_driver_mappings"`
+		NotesURL              string         `json:"notes_url"`
+		ObjectType            string         `json:"object_type"`
+		URL                   string         `json:"url"`
+		VMCount               int            `json:"virtual_machine_count"`
+	}
+
+	// NewPlatform represents the data required to create a new platform.
+	NewPlatform struct {
+		Name          string         `json:"name"`
+		CustomFields  map[string]any `json:"custom_fields,omitempty"`
+		Description   string         `json:"description,omitempty"`
+		Manufacturer  string         `json:"manufacturer,omitempty"`
+		NapalmArgs    any            `json:"napalm_args,omitempty"`
+		NapalmDriver  string         `json:"napalm_driver,omitempty"`
+		NetworkDriver string         `json:"network_driver,omitempty"`
+		Relationships map[string]any `json:"relationships,omitempty"`
+	}
+)

--- a/types/dcim_rack.go
+++ b/types/dcim_rack.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type (
+	// Rack : Data type entry for a Rack in Nautobot.
+	Rack struct {
+		ID             uuid.UUID      `json:"id"`
+		AssetTag       *string        `json:"asset_tag"`
+		Comments       string         `json:"comments"`
+		Created        time.Time      `json:"created"`
+		CustomFields   map[string]any `json:"custom_fields"`
+		DescUnits      bool           `json:"desc_units"`
+		DeviceCount    int            `json:"device_count"`
+		Display        string         `json:"display"`
+		FacilityID     *string        `json:"facility_id"`
+		LastUpdated    time.Time      `json:"last_updated"`
+		Location       Location       `json:"location"`
+		Name           string         `json:"name"`
+		NaturalSlug    string         `json:"natural_slug"`
+		NotesURL       string         `json:"notes_url"`
+		ObjectType     string         `json:"object_type"`
+		OuterDepth     *int           `json:"outer_depth"`
+		OuterUnit      *LabelValue    `json:"outer_unit"`
+		OuterWidth     *int           `json:"outer_width"`
+		PowerFeedCount int            `json:"power_feed_count"`
+		RackGroup      *RackGroup     `json:"rack_group"`
+		Role           *Role          `json:"role"`
+		Serial         string         `json:"serial"`
+		Status         Status         `json:"status"`
+		Tags           []Tag          `json:"tags"`
+		Tenant         *Tenant        `json:"tenant"`
+		Type           *LabelValue    `json:"type"`
+		UHeight        int            `json:"u_height"`
+		URL            string         `json:"url"`
+		Width          LabelValueInt  `json:"width"`
+	}
+
+	// NewRack represents the structure for creating a new Rack in Nautobot.
+	NewRack struct {
+		Location      string         `json:"location"`
+		Name          string         `json:"name"`
+		Status        string         `json:"status"`
+		Width         int            `json:"width"`
+		UHeight       int            `json:"u_height"`
+		AssetTag      string         `json:"asset_tag,omitempty"`
+		Comments      string         `json:"comments,omitempty"`
+		CustomFields  map[string]any `json:"custom_fields,omitempty"`
+		DescUnits     bool           `json:"desc_units,omitempty"`
+		FacilityID    string         `json:"facility_id,omitempty"`
+		OuterDepth    int            `json:"outer_depth,omitempty"`
+		OuterUnit     string         `json:"outer_unit,omitempty"`
+		OuterWidth    int            `json:"outer_width,omitempty"`
+		RackGroup     string         `json:"rack_group,omitempty"`
+		Relationships map[string]any `json:"relationships,omitempty"`
+		Role          string         `json:"role,omitempty"`
+		Serial        string         `json:"serial,omitempty"`
+		Tags          []string       `json:"tags,omitempty"`
+		Tenant        string         `json:"tenant,omitempty"`
+		Type          string         `json:"type,omitempty"`
+	}
+)

--- a/types/dcim_rackgroup.go
+++ b/types/dcim_rackgroup.go
@@ -7,30 +7,32 @@ import (
 )
 
 type (
-	// Namespace : Represents a namespace in Nautobot.
-	Namespace struct {
+	// RackGroup : Data type entry for a RackGroup in Nautobot.
+	RackGroup struct {
 		ID           uuid.UUID      `json:"id"`
 		Created      time.Time      `json:"created"`
 		CustomFields map[string]any `json:"custom_fields"`
 		Description  string         `json:"description"`
 		Display      string         `json:"display"`
 		LastUpdated  time.Time      `json:"last_updated"`
-		Location     *Location      `json:"location"`
+		Location     Location       `json:"location"`
 		Name         string         `json:"name"`
 		NaturalSlug  string         `json:"natural_slug"`
 		NotesURL     string         `json:"notes_url"`
 		ObjectType   string         `json:"object_type"`
-		Tags         []Tag          `json:"tags"`
+		Parent       *RackGroup     `json:"parent"`
+		RackCount    int            `json:"rack_count"`
+		TreeDepth    *int           `json:"tree_depth"`
 		URL          string         `json:"url"`
 	}
 
-	// NewNamespace : Represents a new namespace to be created in Nautobot.
-	NewNamespace struct {
-		Name          string         `json:"name"`
+	// NewRackGroup represents the structure for creating a new RackGroup in Nautobot.
+	NewRackGroup struct {
 		CustomFields  map[string]any `json:"custom_fields,omitempty"`
 		Description   string         `json:"description,omitempty"`
-		Location      string         `json:"location,omitempty"`
+		Location      string         `json:"location"`
+		Name          string         `json:"name"`
+		Parent        string         `json:"parent,omitempty"`
 		Relationships map[string]any `json:"relationships,omitempty"`
-		Tags          []string       `json:"tags,omitempty"`
 	}
 )

--- a/types/dcim_region.go
+++ b/types/dcim_region.go
@@ -1,0 +1,20 @@
+package types
+
+type (
+	// Region : defines a region object in Nautobot
+	Region struct {
+		ID           string         `json:"id"`
+		Created      string         `json:"created"`
+		CustomFields map[string]any `json:"custom_fields"`
+		Depth        int            `json:"_depth"`
+		Description  string         `json:"description" datastore:",noindex"`
+		Display      string         `json:"display"`
+		LastUpdated  string         `json:"last_updated"`
+		Name         string         `json:"name"`
+		NotesURL     string         `json:"notes_url"`
+		Parent       *Region        `json:"parent"`
+		SiteCount    int            `json:"site_count"`
+		Slug         string         `json:"slug"`
+		URL          string         `json:"url"`
+	}
+)

--- a/types/dcim_site.go
+++ b/types/dcim_site.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"encoding/json"
+
+	"github.com/neverbeencloser/gonautobot/types/nested"
+)
+
+type (
+	// Site : Data representation of a Site model in Nautobot.
+	Site struct {
+		ASN                 *int            `json:"asn"`
+		CircuitCount        int             `json:"circuit_count"`
+		Comments            string          `json:"comments" datastore:",noindex"`
+		ContactEmail        string          `json:"contact_email"`
+		ContactName         string          `json:"contact_name"`
+		ContactPhone        string          `json:"contact_phone"`
+		Created             string          `json:"created"`
+		CustomFields        map[string]any  `json:"custom_fields"`
+		Description         string          `json:"description"`
+		DeviceCount         int             `json:"device_count"`
+		Display             string          `json:"display"`
+		Facility            string          `json:"facility"`
+		ID                  string          `json:"id"`
+		LastUpdated         string          `json:"last_updated"`
+		Latitude            json.RawMessage `json:"latitude"`
+		Longitude           json.RawMessage `json:"longitude"`
+		Name                string          `json:"name"`
+		NotesURL            string          `json:"notes_url"`
+		PhysicalAddress     string          `json:"physical_address"`
+		PrefixCount         int             `json:"prefix_count"`
+		RackCount           int             `json:"rack_count"`
+		Region              *Region         `json:"region"`
+		ShippingAddress     string          `json:"shipping_address"`
+		Slug                string          `json:"slug"`
+		Status              *LabelValue     `json:"status"`
+		Tags                []Tag           `json:"tags"`
+		Tenant              *nested.Tenant  `json:"tenant"`
+		TimeZone            json.RawMessage `json:"time_zone"`
+		URL                 string          `json:"url"`
+		VirtualMachineCount int             `json:"virtualmachine_count"`
+		VLANCount           int             `json:"vlan_count"`
+	}
+)

--- a/types/dcim_softwareimage.go
+++ b/types/dcim_softwareimage.go
@@ -1,0 +1,48 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type (
+	// SoftwareImageFile represents a software image file in Nautobot.
+	SoftwareImageFile struct {
+		ID                  uuid.UUID       `json:"id"`
+		Created             time.Time       `json:"created"`
+		CustomFields        map[string]any  `json:"custom_fields"`
+		DefaultImage        bool            `json:"default_image"`
+		Display             string          `json:"display"`
+		DownloadURL         string          `json:"download_url"`
+		ExternalIntegration *Object         `json:"external_integration"`
+		HashingAlgorithm    string          `json:"hashing_algorithm"`
+		ImageFileChecksum   string          `json:"image_file_checksum"`
+		ImageFileName       string          `json:"image_file_name"`
+		ImageFileSize       *int            `json:"image_file_size"`
+		LastUpdated         time.Time       `json:"last_updated"`
+		NaturalSlug         string          `json:"natural_slug"`
+		NotesURL            string          `json:"notes_url"`
+		ObjectType          string          `json:"object_type"`
+		SoftwareVersion     SoftwareVersion `json:"software_version"`
+		Status              Status          `json:"status"`
+		Tags                []Tag           `json:"tags"`
+		URL                 string          `json:"url"`
+	}
+
+	// NewSoftwareImageFile represents the data required to create a new software image file.
+	NewSoftwareImageFile struct {
+		ImageFileName       string         `json:"image_file_name"`
+		SoftwareVersion     string         `json:"software_version"`
+		Status              string         `json:"status"`
+		CustomFields        map[string]any `json:"custom_fields,omitempty"`
+		DefaultImage        bool           `json:"default_image"`
+		DownloadURL         string         `json:"download_url,omitempty"`
+		ExternalIntegration string         `json:"external_integration,omitempty"`
+		HashingAlgorithm    string         `json:"hashing_algorithm,omitempty"`
+		ImageFileChecksum   string         `json:"image_file_checksum,omitempty"`
+		ImageFileSize       int            `json:"image_file_size,omitempty"`
+		Relationships       map[string]any `json:"relationships,omitempty"`
+		Tags                []string       `json:"tags,omitempty"`
+	}
+)

--- a/types/dcim_softwareversion.go
+++ b/types/dcim_softwareversion.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type (
+	// SoftwareVersion represents a software version in Nautobot.
+	SoftwareVersion struct {
+		ID               uuid.UUID      `json:"id"`
+		Alias            string         `json:"alias"`
+		Created          time.Time      `json:"created"`
+		CustomFields     map[string]any `json:"custom_fields"`
+		Display          string         `json:"display"`
+		DocumentationURL string         `json:"documentation_url"`
+		EndOfSupportDate *string        `json:"end_of_support_date"`
+		LastUpdated      time.Time      `json:"last_updated"`
+		LongTermSupport  bool           `json:"long_term_support"`
+		NaturalSlug      string         `json:"natural_slug"`
+		NotesURL         string         `json:"notes_url"`
+		ObjectType       string         `json:"object_type"`
+		Platform         Platform       `json:"platform"`
+		PreRelease       bool           `json:"pre_release"`
+		ReleaseDate      *string        `json:"release_date"`
+		Status           Status         `json:"status"`
+		Tags             []Tag          `json:"tags"`
+		URL              string         `json:"url"`
+		Version          string         `json:"version"`
+	}
+
+	// NewSoftwareVersion represents the data required to create a new software version.
+	NewSoftwareVersion struct {
+		Platform         string         `json:"platform"`
+		Status           string         `json:"status"`
+		Version          string         `json:"version"`
+		Alias            string         `json:"alias,omitempty"`
+		CustomFields     map[string]any `json:"custom_fields,omitempty"`
+		DocumentationURL string         `json:"documentation_url,omitempty"`
+		EndOfSupportDate string         `json:"end_of_support_date,omitempty"`
+		LongTermSupport  bool           `json:"long_term_support"`
+		PreRelease       bool           `json:"pre_release"`
+		ReleaseDate      string         `json:"release_date,omitempty"`
+		Tags             []string       `json:"tags,omitempty"`
+	}
+)

--- a/types/ipam_vrf.go
+++ b/types/ipam_vrf.go
@@ -4,34 +4,33 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/neverbeencloser/gonautobot/types/nested"
 )
 
 type (
 	// VRF : Data type entry for a VRF in Nautobot.
 	VRF struct {
-		ID                    uuid.UUID       `json:"id"`
-		Created               time.Time       `json:"created"`
-		CustomFields          map[string]any  `json:"custom_fields"`
-		Description           string          `json:"description"`
-		Devices               []nested.Device `json:"devices"`
-		Display               string          `json:"display"`
-		ExportTargets         []Object        `json:"export_targets"`
-		ImportTargets         []Object        `json:"import_targets"`
-		LastUpdated           time.Time       `json:"last_updated"`
-		Name                  string          `json:"name"`
-		Namespace             Namespace       `json:"namespace"`
-		NaturalSlug           string          `json:"natural_slug"`
-		NotesURL              string          `json:"notes_url"`
-		ObjectType            string          `json:"object_type"`
-		Prefixes              []Prefix        `json:"prefixes"`
-		RD                    string          `json:"rd"`
-		Status                *Status         `json:"status"`
-		Tags                  []Tag           `json:"tags"`
-		Tenant                *Tenant         `json:"tenant"`
-		URL                   string          `json:"url"`
-		VirtualDeviceContexts []Object        `json:"virtual_device_contexts"`
-		VirtualMachines       []Object        `json:"virtual_machines"`
+		ID                    uuid.UUID      `json:"id"`
+		Created               time.Time      `json:"created"`
+		CustomFields          map[string]any `json:"custom_fields"`
+		Description           string         `json:"description"`
+		Devices               []Device       `json:"devices"`
+		Display               string         `json:"display"`
+		ExportTargets         []Object       `json:"export_targets"`
+		ImportTargets         []Object       `json:"import_targets"`
+		LastUpdated           time.Time      `json:"last_updated"`
+		Name                  string         `json:"name"`
+		Namespace             Namespace      `json:"namespace"`
+		NaturalSlug           string         `json:"natural_slug"`
+		NotesURL              string         `json:"notes_url"`
+		ObjectType            string         `json:"object_type"`
+		Prefixes              []Prefix       `json:"prefixes"`
+		RD                    string         `json:"rd"`
+		Status                *Status        `json:"status"`
+		Tags                  []Tag          `json:"tags"`
+		Tenant                *Tenant        `json:"tenant"`
+		URL                   string         `json:"url"`
+		VirtualDeviceContexts []Object       `json:"virtual_device_contexts"`
+		VirtualMachines       []Object       `json:"virtual_machines"`
 	}
 
 	// NewVRF : Structured input for a new VRF record in Nautobot.

--- a/types/virtualization_cluster.go
+++ b/types/virtualization_cluster.go
@@ -2,8 +2,6 @@ package types
 
 import (
 	"time"
-
-	"github.com/neverbeencloser/gonautobot/types/nested"
 )
 
 // Cluster : Cerebro Cluster data representation in Nautobot.
@@ -20,11 +18,11 @@ type Cluster struct {
 		ObjectType string `json:"object_type"`
 		URL        string `json:"url"`
 	} `json:"cluster_type"`
-	ClusterGroup any              `json:"cluster_group"`
-	Tenant       *Tenant          `json:"tenant"`
-	Location     *nested.Location `json:"location"`
-	Created      time.Time        `json:"created"`
-	LastUpdated  time.Time        `json:"last_updated"`
-	NotesURL     string           `json:"notes_url"`
-	CustomFields map[string]any   `json:"custom_fields"`
+	ClusterGroup any            `json:"cluster_group"`
+	Tenant       *Tenant        `json:"tenant"`
+	Location     *Location      `json:"location"`
+	Created      time.Time      `json:"created"`
+	LastUpdated  time.Time      `json:"last_updated"`
+	NotesURL     string         `json:"notes_url"`
+	CustomFields map[string]any `json:"custom_fields"`
 }


### PR DESCRIPTION
### What
 - refactor: moving all existing types into a flat `types/` package
 - final PR: moving `dcim` types into `types` pkg

### Why
 - to accurately model `depth=1` queries, types need to be able to reference each other; the current layout is causing circular imports (e.g., dcim <-> ipam)
