### PR TITLE
refactor: update Provider to use newer field standards and methods

### DIFF
--- a/circuits/provider.go
+++ b/circuits/provider.go
@@ -1,55 +1,30 @@
 package circuits
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"net/url"
-	"time"
 
+	"github.com/google/uuid"
+	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
 )
 
-type (
-	// Provider : defines a circuit provider in Nautobot
-	Provider struct {
-		ID           string         `json:"id"`
-		Display      string         `json:"display"`
-		URL          string         `json:"url"`
-		Name         string         `json:"name"`
-		Slug         string         `json:"slug"`
-		Asn          int            `json:"asn"`
-		Account      string         `json:"account"`
-		PortalURL    string         `json:"portal_url"`
-		NocContact   string         `json:"noc_contact"`
-		AdminContact string         `json:"admin_contact"`
-		Comments     string         `json:"comments"`
-		CircuitCount int            `json:"circuit_count"`
-		Created      string         `json:"created"`
-		LastUpdated  time.Time      `json:"last_updated"`
-		Tags         []types.Tag    `json:"tags"`
-		NotesURL     string         `json:"notes_url"`
-		CustomFields map[string]any `json:"custom_fields"`
-	}
+const (
+	circuitsEndpointProvider = "circuits/providers/"
 )
 
-// ProviderFilter : Go function to process requests for the endpoint: /api/circuits/providers/
-//
-// https://demo.nautobot.com/api/docs/#/circuits/circuits_providers_list
-func (c *Client) ProviderFilter(q *url.Values) ([]Provider, error) {
-	req, err := c.Request(http.MethodGet, "circuits/providers/", nil, q)
-	if err != nil {
-		return nil, err
-	}
+// ProviderGet : Get a Provider by UUID identifier.
+func (c *Client) ProviderGet(id uuid.UUID) (*types.Provider, error) {
+	return core.Get[types.Provider](c.Client, circuitsEndpointProvider, id)
+}
 
-	resp := new(types.ResponseList)
-	ret := make([]Provider, 0)
-	if err = c.UnmarshalDo(req, resp); err != nil {
-		return ret, err
-	}
+// ProviderFilter : Get a list of Providers based on query parameters.
+func (c *Client) ProviderFilter(q *url.Values) ([]types.Provider, error) {
+	resp := make([]types.Provider, 0)
+	return resp, core.Paginate[types.Provider](c.Client, circuitsEndpointProvider, q, &resp)
+}
 
-	if err = json.Unmarshal(resp.Results, &ret); err != nil {
-		err = fmt.Errorf("GetProviders.error.json.Unmarshall(%w)", err)
-	}
-	return ret, err
+// ProviderAll : Get all Providers in Nautobot.
+func (c *Client) ProviderAll() ([]types.Provider, error) {
+	resp := make([]types.Provider, 0)
+	return resp, core.Paginate[types.Provider](c.Client, circuitsEndpointProvider, nil, &resp)
 }

--- a/tests/circuits_provider_test.go
+++ b/tests/circuits_provider_test.go
@@ -1,13 +1,25 @@
 package nautobot_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"path"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
 )
+
+func TestClient_GetProvider(t *testing.T) {
+	gock.New(testURL).Get("circuits/providers/").Reply(200).
+		File(path.Join("fixtures", "circuits", "provider_200_1.json"))
+
+	circuit, err := testClient.Circuits.ProviderGet(uuid.MustParse("8e384236-9ff5-4f71-8418-1d607177e10e"))
+	require.NoError(t, err)
+	assert.Equal(t, "8e384236-9ff5-4f71-8418-1d607177e10e", circuit.ID.String())
+	assert.Equal(t, 7018, circuit.Asn)
+}
 
 func TestClient_GetProviders(t *testing.T) {
 	gock.New(testURL).Get("circuits/providers/").Reply(200).

--- a/tests/fixtures/circuits/provider_200_1.json
+++ b/tests/fixtures/circuits/provider_200_1.json
@@ -1,0 +1,25 @@
+{
+	"id": "8e384236-9ff5-4f71-8418-1d607177e10e",
+	"object_type": "circuits.provider",
+	"display": "AT&T",
+	"url": "https://demo.nautobot.com/api/circuits/providers/8e384236-9ff5-4f71-8418-1d607177e10e/",
+	"natural_slug": "at-t_8e38",
+	"circuit_count": 0,
+	"name": "AT&T",
+	"asn": 7018,
+	"account": "",
+	"portal_url": "",
+	"noc_contact": "",
+	"admin_contact": "",
+	"comments": "",
+	"created": "2023-09-21T00:00:00Z",
+	"last_updated": "2023-09-21T19:46:57.405953Z",
+	"tags": [],
+	"notes_url": "https://demo.nautobot.com/api/circuits/providers/8e384236-9ff5-4f71-8418-1d607177e10e/notes/",
+	"custom_fields": {
+		"emails_for_circuit_maintenance_plugin": null,
+		"emails_circuit_maintenances": null,
+		"provider_parser_for_circuit_maintenance_plugin": null,
+		"provider_parser_circuit_maintenances": null
+	}
+}

--- a/tests/fixtures/circuits/providers_200_1.json
+++ b/tests/fixtures/circuits/providers_200_1.json
@@ -1,6 +1,6 @@
 {
-	"count": 16,
-	"next": "https://demo.nautobot.com/api/circuits/providers/?depth=1&limit=2&offset=2",
+	"count": 2,
+	"next": "",
 	"previous": null,
 	"results": [
 		{

--- a/types/circuits_provider.go
+++ b/types/circuits_provider.go
@@ -2,12 +2,14 @@ package types
 
 import (
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type (
 	// Provider : defines a circuit provider in Nautobot
 	Provider struct {
-		ID           string         `json:"id"`
+		ID           uuid.UUID      `json:"id"`
 		Display      string         `json:"display"`
 		URL          string         `json:"url"`
 		Name         string         `json:"name"`
@@ -19,7 +21,7 @@ type (
 		AdminContact string         `json:"admin_contact"`
 		Comments     string         `json:"comments"`
 		CircuitCount int            `json:"circuit_count"`
-		Created      string         `json:"created"`
+		Created      time.Time      `json:"created"`
 		LastUpdated  time.Time      `json:"last_updated"`
 		Tags         []Tag          `json:"tags"`
 		NotesURL     string         `json:"notes_url"`


### PR DESCRIPTION
## What
 - update Provider to use newer field standards and methods
 - add `ProviderGet` and `ProviderAll` methods
 - remove duplicate type

## Why
 - standardize on stricter fields for better type checking
 - use generic method handlers