### PR TITLE
refactor: update VLAN methods to use modern field standard

### DIFF
--- a/ipam/vlan.go
+++ b/ipam/vlan.go
@@ -1,30 +1,45 @@
 package ipam
 
 import (
-	"fmt"
-	"net/http"
 	"net/url"
 
+	"github.com/google/uuid"
 	"github.com/neverbeencloser/gonautobot/core"
 	"github.com/neverbeencloser/gonautobot/types"
 )
 
-// VLANGet : Go function to process requests for the endpoint: /api/ipam/vlans/:id/
-//
-// https://demo.nautobot.com/api/docs/#/ipam/ipam_vlans_retrieve
-func (c *Client) VLANGet(uuid string) (*types.VLAN, error) {
-	req, err := c.Request(http.MethodGet, fmt.Sprintf("ipam/vlans/%s/", url.PathEscape(uuid)), nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	ret := new(types.VLAN)
-	return ret, c.UnmarshalDo(req, ret)
+const (
+	ipamEndpointVLAN = "ipam/vlans/"
+)
+
+// VLANGet : Get a VLAN by UUID identifier.
+func (c *Client) VLANGet(id uuid.UUID) (*types.VLAN, error) {
+	return core.Get[types.VLAN](c.Client, ipamEndpointVLAN, id)
 }
 
-// VLANFilter : Go function to process requests for the endpoint: /api/ipam/vlans/
-//
-// https://demo.nautobot.com/api/docs/#/ipam/ipam_vlans_list
+// VLANFilter : Get a list of VLANs based on query parameters.
 func (c *Client) VLANFilter(q *url.Values) ([]types.VLAN, error) {
-	resp := make([]types.VLAN, 0)
-	return resp, core.Paginate[types.VLAN](c.Client, "ipam/vlans/", q, &resp)
+	vlans := make([]types.VLAN, 0)
+	return vlans, core.Paginate[types.VLAN](c.Client, ipamEndpointVLAN, q, &vlans)
+}
+
+// VLANAll : Get all VLANs in Nautobot.
+func (c *Client) VLANAll() ([]types.VLAN, error) {
+	vlans := make([]types.VLAN, 0)
+	return vlans, core.Paginate[types.VLAN](c.Client, ipamEndpointVLAN, nil, &vlans)
+}
+
+// VLANCreate : Generate a new VLAN record in Nautobot.
+func (c *Client) VLANCreate(obj types.NewVLAN) (*types.VLAN, error) {
+	return core.Create[types.VLAN, types.NewVLAN](c.Client, ipamEndpointVLAN, obj)
+}
+
+// VLANDelete : Delete a VLAN by UUID identifier.
+func (c *Client) VLANDelete(id uuid.UUID) error {
+	return core.Delete(c.Client, ipamEndpointVLAN, id)
+}
+
+// VLANUpdate : Update an existing VLAN record in Nautobot.
+func (c *Client) VLANUpdate(id uuid.UUID, patch map[string]any) (*types.VLAN, error) {
+	return core.Update[types.VLAN](c.Client, ipamEndpointVLAN, id, patch)
 }

--- a/tests/fixtures/ipam/vlan_update_200_1.json
+++ b/tests/fixtures/ipam/vlan_update_200_1.json
@@ -1,0 +1,109 @@
+{
+	"id": "01acc3fb-d449-4f36-9789-df5503206528",
+	"object_type": "ipam.vlan",
+	"display": "dfw01-103-mgmt (99)",
+	"url": "https://demo.nautobot.com/api/ipam/vlans/01acc3fb-d449-4f36-9789-df5503206528/",
+	"natural_slug": "01acc3fb-d449-4f36-9789-df5503206528_01ac",
+	"prefix_count": 1,
+	"vid": 99,
+	"name": "dfw01-103-mgmt",
+	"description": "updated description",
+	"vlan_group": null,
+	"status": {
+		"id": "9f38bab4-4b47-4e77-b50c-fda62817b2db",
+		"object_type": "extras.status",
+		"display": "Active",
+		"url": "https://demo.nautobot.com/api/extras/statuses/9f38bab4-4b47-4e77-b50c-fda62817b2db/",
+		"natural_slug": "active_9f38",
+		"name": "Active",
+		"color": "4caf50",
+		"description": "Unit is active",
+		"created": "2023-09-21T00:00:00Z",
+		"last_updated": "2023-09-21T19:46:47.125611Z",
+		"notes_url": "https://demo.nautobot.com/api/extras/statuses/9f38bab4-4b47-4e77-b50c-fda62817b2db/notes/",
+		"custom_fields": {}
+	},
+	"role": {
+		"id": "5f965b05-bca7-48a4-b5d0-c3360c102c46",
+		"object_type": "extras.role",
+		"display": "mgmt",
+		"url": "https://demo.nautobot.com/api/extras/roles/5f965b05-bca7-48a4-b5d0-c3360c102c46/",
+		"natural_slug": "mgmt_5f96",
+		"name": "mgmt",
+		"color": "9e9e9e",
+		"description": "",
+		"weight": 1000,
+		"created": "2023-10-31T00:00:00Z",
+		"last_updated": "2023-10-31T18:51:42.395094Z",
+		"notes_url": "https://demo.nautobot.com/api/extras/roles/5f965b05-bca7-48a4-b5d0-c3360c102c46/notes/",
+		"custom_fields": {}
+	},
+	"tenant": {
+		"id": "1f7fbd07-111a-4091-81d0-f34db26d961d",
+		"object_type": "tenancy.tenant",
+		"display": "Nautobot Airports",
+		"url": "https://demo.nautobot.com/api/tenancy/tenants/1f7fbd07-111a-4091-81d0-f34db26d961d/",
+		"natural_slug": "nautobot-airports_1f7f",
+		"name": "Nautobot Airports",
+		"description": "atc.nautobot.com",
+		"comments": "",
+		"tenant_group": null,
+		"created": "2023-09-21T00:00:00Z",
+		"last_updated": "2023-09-21T19:46:55.974813Z",
+		"notes_url": "https://demo.nautobot.com/api/tenancy/tenants/1f7fbd07-111a-4091-81d0-f34db26d961d/notes/",
+		"custom_fields": {}
+	},
+	"locations": [
+		{
+			"id": "bbca5b70-668f-4220-afd8-48904b88f269",
+			"object_type": "dcim.location",
+			"display": "Americas → United States → DFW01",
+			"url": "https://demo.nautobot.com/api/dcim/locations/bbca5b70-668f-4220-afd8-48904b88f269/",
+			"natural_slug": "dfw01_united-states_americas_bbca",
+			"time_zone": null,
+			"name": "DFW01",
+			"description": "",
+			"facility": "Dallas/Fort Worth International Airport",
+			"asn": null,
+			"physical_address": "",
+			"shipping_address": "",
+			"latitude": null,
+			"longitude": null,
+			"contact_name": "",
+			"contact_phone": "",
+			"contact_email": "",
+			"comments": "",
+			"parent": {
+				"id": "26001bdf-9b5e-404a-a349-053b483569c2",
+				"object_type": "dcim.location",
+				"url": "https://demo.nautobot.com/api/dcim/locations/26001bdf-9b5e-404a-a349-053b483569c2/"
+			},
+			"location_type": {
+				"id": "db20360d-ba02-48eb-8297-7013f3f6b9ca",
+				"object_type": "dcim.locationtype",
+				"url": "https://demo.nautobot.com/api/dcim/location-types/db20360d-ba02-48eb-8297-7013f3f6b9ca/"
+			},
+			"status": {
+				"id": "9f38bab4-4b47-4e77-b50c-fda62817b2db",
+				"object_type": "extras.status",
+				"url": "https://demo.nautobot.com/api/extras/statuses/9f38bab4-4b47-4e77-b50c-fda62817b2db/"
+			},
+			"tenant": {
+				"id": "1f7fbd07-111a-4091-81d0-f34db26d961d",
+				"object_type": "tenancy.tenant",
+				"url": "https://demo.nautobot.com/api/tenancy/tenants/1f7fbd07-111a-4091-81d0-f34db26d961d/"
+			},
+			"created": "2023-10-31T00:00:00Z",
+			"last_updated": "2024-08-30T04:03:25.421773Z",
+			"notes_url": "https://demo.nautobot.com/api/dcim/locations/bbca5b70-668f-4220-afd8-48904b88f269/notes/",
+			"custom_fields": {
+				"site_type": "POP"
+			}
+		}
+	],
+	"created": "2023-09-21T00:00:00Z",
+	"last_updated": "2023-09-21T19:48:04.449250Z",
+	"tags": [],
+	"notes_url": "https://demo.nautobot.com/api/ipam/vlans/01acc3fb-d449-4f36-9789-df5503206528/notes/",
+	"custom_fields": {}
+}

--- a/tests/ipam_vlan_test.go
+++ b/tests/ipam_vlan_test.go
@@ -1,29 +1,123 @@
 package nautobot_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"net/url"
 	"path"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/neverbeencloser/gonautobot/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 )
 
-func TestClient_GetVLAN(t *testing.T) {
-	gock.New(testURL).Get("ipam/vlans/01acc3fb-d449-4f36-9789-df5503206528/").Reply(200).
+const (
+	testVLANID = "01acc3fb-d449-4f36-9789-df5503206528"
+)
+
+func TestClient_VLANGet(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(testURL).Get("ipam/vlans/" + testVLANID + "/").Reply(200).
 		File(path.Join("fixtures", "ipam", "vlan_200_1.json"))
 
-	resp, err := testClient.Ipam.VLANGet("01acc3fb-d449-4f36-9789-df5503206528")
+	id, err := uuid.Parse(testVLANID)
 	require.NoError(t, err)
-	assert.Equal(t, 99, resp.VID)
+
+	resp, err := testClient.Ipam.VLANGet(id)
+	require.NoError(t, err)
+	assert.Equal(t, "dfw01-103-mgmt", resp.Name)
+	assert.Equal(t, id, resp.ID)
 }
 
-func TestClient_GetVLANs(t *testing.T) {
+func TestClient_VLANFilter(t *testing.T) {
+	defer gock.Off()
+
 	gock.New(testURL).Get("ipam/vlans/").Reply(200).
 		File(path.Join("fixtures", "ipam", "vlans_200_1.json"))
 
-	resp, err := testClient.Ipam.VLANFilter(&url.Values{"offset": {"50"}})
+	q := &url.Values{}
+	q.Set("name", "dfw01-103-mgmt")
+
+	resp, err := testClient.Ipam.VLANFilter(q)
 	require.NoError(t, err)
+
+	assert.NotEmpty(t, resp)
 	assert.Len(t, resp, 2)
+	assert.Equal(t, resp[0].ID, uuid.MustParse(testVLANID))
+}
+
+func TestClient_VLANAll(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(testURL).Get("ipam/vlans/").Reply(200).
+		File(path.Join("fixtures", "ipam", "vlans_200_1.json"))
+
+	resp, err := testClient.Ipam.VLANAll()
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, resp)
+	assert.Len(t, resp, 2)
+	assert.Equal(t, resp[0].ID, uuid.MustParse(testVLANID))
+}
+
+func TestClient_VLANCreate(t *testing.T) {
+	defer gock.Off()
+
+	newVLAN := types.NewVLAN{
+		Name:        "dfw01-103-mgmt",
+		Status:      "9f38bab4-4b47-4e77-b50c-fda62817b2db",
+		VID:         99,
+		Description: "",
+		Role:        "5f965b05-bca7-48a4-b5d0-c3360c102c46",
+		Tenant:      "1f7fbd07-111a-4091-81d0-f34db26d961d",
+	}
+
+	gock.New(testURL).Post("ipam/vlans/").
+		JSON(newVLAN).
+		Reply(201).
+		File(path.Join("fixtures", "ipam", "vlan_200_1.json"))
+
+	resp, err := testClient.Ipam.VLANCreate(newVLAN)
+	require.NoError(t, err)
+
+	assert.Equal(t, newVLAN.Name, resp.Name)
+	assert.Equal(t, newVLAN.Description, resp.Description)
+	assert.Equal(t, uuid.MustParse(testVLANID), resp.ID)
+}
+
+func TestClient_VLANUpdate(t *testing.T) {
+	defer gock.Off()
+
+	updateData := map[string]any{
+		"description": "updated description",
+	}
+
+	gock.New(testURL).Patch("ipam/vlans/" + testVLANID + "/").
+		JSON(updateData).
+		Reply(200).
+		File(path.Join("fixtures", "ipam", "vlan_update_200_1.json"))
+
+	id, err := uuid.Parse(testVLANID)
+	require.NoError(t, err)
+
+	resp, err := testClient.Ipam.VLANUpdate(id, updateData)
+	require.NoError(t, err)
+
+	assert.Equal(t, "updated description", resp.Description)
+	assert.Equal(t, id, resp.ID)
+}
+
+func TestClient_VLANDelete(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(testURL).Delete("ipam/vlans/" + testVLANID + "/").Reply(204)
+
+	id, err := uuid.Parse(testVLANID)
+	require.NoError(t, err)
+
+	err = testClient.Ipam.VLANDelete(id)
+	require.NoError(t, err)
+	assert.True(t, gock.IsDone())
 }

--- a/types/ipam_vlan.go
+++ b/types/ipam_vlan.go
@@ -1,27 +1,46 @@
 package types
 
-import "github.com/neverbeencloser/gonautobot/types/nested"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 type (
 	// VLAN : defines a vlan entry in Nautobot
 	VLAN struct {
-		ID           string                 `json:"id"`
-		Created      string                 `json:"created"`
-		CustomFields map[string]interface{} `json:"custom_fields"`
-		Description  string                 `json:"description"`
-		Display      string                 `json:"display"`
-		Group        *nested.SecretsGroup   `json:"group"`
-		LastUpdated  string                 `json:"last_updated"`
-		Location     *nested.Location       `json:"location"`
-		Name         string                 `json:"name"`
-		NotesURL     string                 `json:"notes_url"`
-		PrefixCount  int                    `json:"prefix_count"`
-		Role         *nested.Role           `json:"role"`
-		Site         *nested.Site           `json:"site"`
-		Status       *LabelValue            `json:"status"`
-		Tags         []Tag                  `json:"tags"`
-		Tenant       *nested.Tenant         `json:"tenant"`
-		URL          string                 `json:"url"`
-		VID          int                    `json:"vid"`
+		ID           uuid.UUID      `json:"id"`
+		Created      time.Time      `json:"created"`
+		CustomFields map[string]any `json:"custom_fields"`
+		Description  string         `json:"description"`
+		Display      string         `json:"display"`
+		LastUpdated  time.Time      `json:"last_updated"`
+		Locations    []Location     `json:"location"`
+		Name         string         `json:"name"`
+		NaturalSlug  string         `json:"natural_slug"`
+		NotesURL     string         `json:"notes_url"`
+		ObjectType   string         `json:"object_type"`
+		PrefixCount  int            `json:"prefix_count"`
+		Role         *Role          `json:"role"`
+		Status       Status         `json:"status"`
+		Tags         []Tag          `json:"tags"`
+		Tenant       *Tenant        `json:"tenant"`
+		URL          string         `json:"url"`
+		VID          int            `json:"vid"`
+		VLANGroup    *Object        `json:"vlan_group"`
+	}
+
+	// NewVLAN : defines the information needed to create a new VLAN in Nautobot
+	NewVLAN struct {
+		Name          string         `json:"name"`
+		Status        string         `json:"status"`
+		VID           int            `json:"vid"`
+		CustomFields  map[string]any `json:"custom_fields,omitempty"`
+		Description   string         `json:"description,omitempty"`
+		Relationships map[string]any `json:"relationships,omitempty"`
+		Role          string         `json:"role,omitempty"`
+		Tags          []string       `json:"tags,omitempty"`
+		Tenant        string         `json:"tenant,omitempty"`
+		VLANGroup     string         `json:"vlan_group,omitempty"`
 	}
 )


### PR DESCRIPTION
## Summary
- Updated VLAN and NewVLAN types to match 2.x Nautobot field standards
- Refactored VLAN methods to use modern core helpers and UUID identifiers  
- Added comprehensive CRUD operations: VLANAll, VLANCreate, VLANUpdate, VLANDelete
- Updated tests to follow the same pattern as VRF tests

## Changes Made
- **Types** (`types/ipam_vlan.go`): Updated VLAN struct with proper field types (uuid.UUID, time.Time) and added NewVLAN struct
- **Methods** (`ipam/vlan.go`): Refactored to use core.Get, core.Create, core.Update, core.Delete helpers instead of manual HTTP requests
- **Tests** (`tests/ipam_vlan_test.go`): Complete rewrite to match VRF test pattern with comprehensive coverage
- **Fixtures**: Added `vlan_update_200_1.json` for update response mocking

## Test Results
All VLAN tests are passing:
- ✅ `TestClient_VLANGet`
- ✅ `TestClient_VLANFilter`  
- ✅ `TestClient_VLANAll`
- ✅ `TestClient_VLANCreate`
- ✅ `TestClient_VLANUpdate`
- ✅ `TestClient_VLANDelete`

🤖 Generated with [Claude Code](https://claude.ai/code)